### PR TITLE
Add support for explicit sort order on createdDate

### DIFF
--- a/src/main/java/org/phoebus/olog/LogSearchUtil.java
+++ b/src/main/java/org/phoebus/olog/LogSearchUtil.java
@@ -77,6 +77,9 @@ public class LogSearchUtil
         int size = defaultSearchSize;
         int from = 0;
 
+        // Default sort order
+        SortOrder sortOrder = SortOrder.DESC;
+
         for (Entry<String, List<String>> parameter : searchParameters.entrySet())
         {
             switch (parameter.getKey().strip().toLowerCase()) {
@@ -223,6 +226,18 @@ public class LogSearchUtil
                     from = Integer.valueOf(maxFrom.get());
                 }
                 break;
+            case "sort": // Honor sort order if client specifies it
+                List<String> sortList = parameter.getValue();
+                if(sortList != null && sortList.size() > 0){
+                    String sort = sortList.get(0);
+                    if(sort.toUpperCase().startsWith("ASC")){
+                        sortOrder = SortOrder.ASC;
+                    }
+                    else if(sort.toUpperCase().startsWith("DESC")){
+                        sortOrder = SortOrder.DESC;
+                    }
+                }
+                break;
             default:
                 // Unsupported search parameters are ignored
                 break;
@@ -302,7 +317,7 @@ public class LogSearchUtil
             boolQuery.must(levelQuery);
         }
 
-        searchSourceBuilder.sort("createdDate", SortOrder.DESC);
+        searchSourceBuilder.sort("createdDate", sortOrder);
         searchSourceBuilder.query(boolQuery);
         searchSourceBuilder.size(Math.min(searchResultSize, maxSearchSize));
         if (from >= 0)

--- a/src/test/java/org/phoebus/olog/LogSearchUtilTest.java
+++ b/src/test/java/org/phoebus/olog/LogSearchUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+public class LogSearchUtilTest {
+
+    @Test
+    public void testSortOrder() {
+        LogSearchUtil logSearchUtil = new LogSearchUtil();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("sort", Arrays.asList("asc"));
+
+        // Explicit ascending
+        SearchRequest searchRequest = logSearchUtil.buildSearchRequest(params);
+        FieldSortBuilder fieldSortBuilder = (FieldSortBuilder) searchRequest.source().sorts().get(0);
+        assertEquals(SortOrder.ASC, fieldSortBuilder.order());
+        assertEquals("createdDate", fieldSortBuilder.getFieldName());
+
+        params = new LinkedMultiValueMap<>();
+        params.put("sort", Arrays.asList("AsCenDinG"));
+        searchRequest = logSearchUtil.buildSearchRequest(params);
+        fieldSortBuilder = (FieldSortBuilder) searchRequest.source().sorts().get(0);
+        assertEquals(SortOrder.ASC, fieldSortBuilder.order());
+        assertEquals("createdDate", fieldSortBuilder.getFieldName());
+
+        // No sort order => expect descending
+        params = new LinkedMultiValueMap<>();
+        searchRequest = logSearchUtil.buildSearchRequest(params);
+        fieldSortBuilder = (FieldSortBuilder) searchRequest.source().sorts().get(0);
+        assertEquals(SortOrder.DESC, fieldSortBuilder.order());
+        assertEquals("createdDate", fieldSortBuilder.getFieldName());
+
+        //Explicit descending
+        params = new LinkedMultiValueMap<>();
+        params.put("sort", Arrays.asList("desc"));
+        searchRequest = logSearchUtil.buildSearchRequest(params);
+        fieldSortBuilder = (FieldSortBuilder) searchRequest.source().sorts().get(0);
+        assertEquals(SortOrder.DESC, fieldSortBuilder.order());
+        assertEquals("createdDate", fieldSortBuilder.getFieldName());
+
+        params = new LinkedMultiValueMap<>();
+        params.put("sort", Arrays.asList("DEsCendiNG"));
+        searchRequest = logSearchUtil.buildSearchRequest(params);
+        fieldSortBuilder = (FieldSortBuilder) searchRequest.source().sorts().get(0);
+        assertEquals(SortOrder.DESC, fieldSortBuilder.order());
+        assertEquals("createdDate", fieldSortBuilder.getFieldName());
+    }
+}


### PR DESCRIPTION
Client can add request param sort=[asc|desc]. Values are case insensitive and matched only on asc and desc, i.e. ascending/descendiing will work.

Default is still descending, i.e. if client does not specify sort paramter.

#85 