### PR TITLE
Implement reply logic

### DIFF
--- a/src/main/java/org/phoebus/olog/LogResource.java
+++ b/src/main/java/org/phoebus/olog/LogResource.java
@@ -385,7 +385,7 @@ public class LogResource {
             // Check if the original entry already contains the log entry group property
             Property logEntryGroupProperty = LogEntryGroupHelper.getLogEntryGroupProperty(originalLogEntry);
             if (logEntryGroupProperty == null) {
-                logEntryGroupProperty = LogEntryGroupHelper.createNewLogEntryProperty(originalLogEntry);
+                logEntryGroupProperty = LogEntryGroupHelper.createNewLogEntryProperty();
                 originalLogEntry.getProperties().add(logEntryGroupProperty);
                 // Update the original log entry
                 logRepository.update(originalLogEntry);

--- a/src/main/java/org/phoebus/olog/entity/LogEntryGroupHelper.java
+++ b/src/main/java/org/phoebus/olog/entity/LogEntryGroupHelper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Helper class when dealing with replies to log entries.
+ */
+public class LogEntryGroupHelper {
+
+    public static final String LOG_ENTRY_GROUP = "Log Entry Group";
+
+    /**
+     * @param originalLogEntry The log entry to which a user wishes to reply.
+     * @return An {@link Optional} that is empty if the original log entry does not already contain
+     * a log entry group property.
+     */
+    public static Property getLogEntryGroupProperty(Log originalLogEntry){
+        // Check if the original log entry already contains the log entry group property
+        Set<Property> originalLogEntryProperties = originalLogEntry.getProperties();
+        Optional<Property> prop = null;
+        if(originalLogEntryProperties != null){
+            prop =
+                originalLogEntryProperties.stream().filter(property -> property.getName().equals(LOG_ENTRY_GROUP)).findFirst();
+        }
+        return prop.isPresent() ? prop.get() : null;
+    }
+
+    /**
+     * @param originalLogEntry The log entry to which a user wishes to reply.
+     * @return A {@link Property} containing two {@link Attribute}s: one with the unique log entry group id,
+     * one with the title of the original entry.
+     */
+    public static Property createNewLogEntryProperty(Log originalLogEntry){
+        Attribute idAttribute = new Attribute("id", UUID.randomUUID().toString());
+        Attribute titleAttribute = new Attribute("title", originalLogEntry.getTitle());
+        return new Property(LOG_ENTRY_GROUP, Set.of(idAttribute, titleAttribute));
+    }
+}

--- a/src/main/java/org/phoebus/olog/entity/LogEntryGroupHelper.java
+++ b/src/main/java/org/phoebus/olog/entity/LogEntryGroupHelper.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 public class LogEntryGroupHelper {
 
     public static final String LOG_ENTRY_GROUP = "Log Entry Group";
+    public static final String ATTRIBUTE_ID = "id";
 
     /**
      * @param originalLogEntry The log entry to which a user wishes to reply.
@@ -46,13 +47,11 @@ public class LogEntryGroupHelper {
     }
 
     /**
-     * @param originalLogEntry The log entry to which a user wishes to reply.
      * @return A {@link Property} containing two {@link Attribute}s: one with the unique log entry group id,
      * one with the title of the original entry.
      */
-    public static Property createNewLogEntryProperty(Log originalLogEntry){
-        Attribute idAttribute = new Attribute("id", UUID.randomUUID().toString());
-        Attribute titleAttribute = new Attribute("title", originalLogEntry.getTitle());
-        return new Property(LOG_ENTRY_GROUP, Set.of(idAttribute, titleAttribute));
+    public static Property createNewLogEntryProperty(){
+        Attribute idAttribute = new Attribute(ATTRIBUTE_ID, UUID.randomUUID().toString());
+        return new Property(LOG_ENTRY_GROUP, Set.of(idAttribute));
     }
 }

--- a/src/site/sphinx/index.rst
+++ b/src/site/sphinx/index.rst
@@ -174,6 +174,13 @@ Create a simple log entry
       ]
  }
 
+Reply to a log entry. This uses the same end point as when creating a log entry, but client must
+send the unique id of the log entry to which the new one is a reply.
+
+**PUT** https://localhost:8181/Olog/logs?inReplyTo=<id>
+
+If <id> does not identify an existing log entry, a HTTP 400 status is returned.
+
 Adding an attachment 
 
 **POST** https://localhost:8181/Olog/logs/attachments/{logId}

--- a/src/test/java/org/phoebus/olog/LogResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTest.java
@@ -440,4 +440,18 @@ public class LogResourceTest extends ResourcesTestBase {
             return match;
         }
     }
+
+    @Test
+    public void testReplyInvalidLogEntryId() throws Exception{
+        when(logbookRepository.findAll()).thenReturn(Arrays.asList(logbook1, logbook2));
+        when(tagRepository.findAll()).thenReturn(Arrays.asList(tag1, tag2));
+        when(logRepository.findById("7"))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Failed to retrieve log"));
+        MockHttpServletRequestBuilder request = put("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "?inReplyTo=7")
+                .content(objectMapper.writeValueAsString(log1))
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+        reset(logRepository);
+    }
 }

--- a/src/test/java/org/phoebus/olog/entity/LogEntryGroupHelperTest.java
+++ b/src/test/java/org/phoebus/olog/entity/LogEntryGroupHelperTest.java
@@ -107,18 +107,8 @@ public class LogEntryGroupHelperTest {
                 .withProperties(Set.of(property1))
                 .build();
 
-        Property logEntryGroupProperty = LogEntryGroupHelper.createNewLogEntryProperty(originalLog);
+        Property logEntryGroupProperty = LogEntryGroupHelper.createNewLogEntryProperty();
         originalLog.getProperties().add(logEntryGroupProperty);
-
-        Log reply = LogBuilder.createLog()
-                .owner("user")
-                .title("title")
-                .withLogbooks(Set.of(logbook1, logbook2))
-                .withTags(Set.of(tag1, tag2))
-                .description("description2")
-                .createDate(Instant.now())
-                .level("Urgent")
-                .build();
 
         Property prop = LogEntryGroupHelper.getLogEntryGroupProperty(originalLog);
         assertNotNull(prop);

--- a/src/test/java/org/phoebus/olog/entity/LogEntryGroupHelperTest.java
+++ b/src/test/java/org/phoebus/olog/entity/LogEntryGroupHelperTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.phoebus.olog.entity.Log.LogBuilder;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class LogEntryGroupHelperTest {
+
+    private Log log1;
+    private Log log2;
+
+    private Logbook logbook1;
+    private Logbook logbook2;
+
+    private Tag tag1;
+    private Tag tag2;
+
+    private Property property1;
+
+    private Instant now = Instant.now();
+
+    @Before
+    public void init() {
+        logbook1 = new Logbook("name1", "user");
+        logbook2 = new Logbook("name2", "user");
+
+        tag1 = new Tag("tag1");
+        tag2 = new Tag("tag2");
+
+        log1 = LogBuilder.createLog()
+                .id(1L)
+                .owner("owner")
+                .title("title")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .description("description1")
+                .withTags(Set.of(tag1, tag2))
+                .createDate(now)
+                .level("Urgent")
+                .build();
+
+        log2 = LogBuilder.createLog()
+                .id(2L)
+                .owner("user")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .description("description2")
+                .createDate(now)
+                .level("Urgent")
+                .build();
+
+        property1 = new Property();
+        property1.setName("prop1");
+        property1.addAttributes(new Attribute("name1", "value1"));
+    }
+
+    @Test
+    public void testAddLogEntryGroupPorpertyNoProperties(){
+
+        Log originalLog = LogBuilder.createLog()
+                .owner("user")
+                .title("original title")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .withTags(Set.of(tag1, tag2))
+                .description("description1")
+                .createDate(Instant.now())
+                .level("Urgent")
+                .build();
+
+        Property prop = LogEntryGroupHelper.getLogEntryGroupProperty(originalLog);
+        assertNull(prop);
+    }
+
+    @Test
+    public void testAddLogEntryGroupPorpertyOriginalHasLogEntryGroup(){
+
+        Log originalLog = LogBuilder.createLog()
+                .owner("user")
+                .title("original title")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .withTags(Set.of(tag1, tag2))
+                .description("description1")
+                .createDate(Instant.now())
+                .level("Urgent")
+                .withProperties(Set.of(property1))
+                .build();
+
+        Property logEntryGroupProperty = LogEntryGroupHelper.createNewLogEntryProperty(originalLog);
+        originalLog.getProperties().add(logEntryGroupProperty);
+
+        Log reply = LogBuilder.createLog()
+                .owner("user")
+                .title("title")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .withTags(Set.of(tag1, tag2))
+                .description("description2")
+                .createDate(Instant.now())
+                .level("Urgent")
+                .build();
+
+        Property prop = LogEntryGroupHelper.getLogEntryGroupProperty(originalLog);
+        assertNotNull(prop);
+    }
+}


### PR DESCRIPTION
This is for #91.

The idea is to be able to remove some logic in the clients, e.g. the need to update the "original" log entry.

Changes are backwards compatible, i.e. clients may still reply using existing client-side logic.