### PR TITLE
Fix for static resources handling

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -154,3 +154,7 @@ defaultMarkup=commonmark
 # Timeout in milliseconds for PropertyProviders. This timeout applies to all providers, i.e.
 # all should finish within this amount of time.
 propertyProvidersTimeout=2000
+
+# Mapping of static resources. Needed as otherwise the web front-end (if present) will intercept and fail to
+# serve a resource like for instance CommonmarkCheatsheet.html
+spring.mvc.static-path-pattern=/Olog/**


### PR DESCRIPTION
Not sure why this has not yet been reported by users, but the CommonmarkCheatsheet.html resource will not be available if a the Olog web front-end is deployed in a particular manner.

This PR should make the static resource handling more robust. 

Phoebus Olog client change is needed and will be pushed.