### PR TITLE
Validation of logbook and tag names

### DIFF
--- a/src/main/java/org/phoebus/olog/LogResource.java
+++ b/src/main/java/org/phoebus/olog/LogResource.java
@@ -224,21 +224,6 @@ public class LogResource {
             handleReply(inReplyTo, log);
         }
         log.setOwner(principal.getName());
-        Set<String> logbookNames = log.getLogbooks().stream().map(l -> l.getName()).collect(Collectors.toSet());
-        Set<String> persistedLogbookNames = new HashSet<>();
-        logbookRepository.findAll().forEach(l -> persistedLogbookNames.add(l.getName()));
-        if (!CollectionUtils.containsAll(persistedLogbookNames, logbookNames)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "One or more invalid logbook name(s)");
-        }
-        Set<Tag> tags = log.getTags();
-        if (tags != null && !tags.isEmpty()) {
-            Set<String> tagNames = tags.stream().map(t -> t.getName()).collect(Collectors.toSet());
-            Set<String> persistedTags = new HashSet<>();
-            tagRepository.findAll().forEach(t -> persistedTags.add(t.getName()));
-            if (!CollectionUtils.containsAll(persistedTags, tagNames)) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "One or more invalid tag name(s)");
-            }
-        }
         log = cleanMarkup(markup, log);
         addPropertiesFromProviders(log);
         Log newLogEntry = logRepository.save(log);
@@ -314,7 +299,6 @@ public class LogResource {
             persistedLog.setLogbooks(log.getLogbooks());
             persistedLog.setTitle(log.getTitle());
 
-            log = cleanMarkup(markup, log);
             Log newLogEntry = logRepository.update(persistedLog);
             return newLogEntry;
         } else {

--- a/src/main/java/org/phoebus/olog/entity/Log.java
+++ b/src/main/java/org/phoebus/olog/entity/Log.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Size;
  * 
  * @author Kunal Shroff
  */
+@ValidLog()
 public class Log implements Serializable
 {
 

--- a/src/main/java/org/phoebus/olog/entity/LogEntryValidator.java
+++ b/src/main/java/org/phoebus/olog/entity/LogEntryValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity;
+
+import org.phoebus.olog.LogbookRepository;
+import org.phoebus.olog.TagRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Custom validator for a {@link Log} object.
+ */
+public class LogEntryValidator implements ConstraintValidator<ValidLog, Log> {
+
+    @Autowired
+    private LogbookRepository logbookRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    private final Logger logger = Logger.getLogger(LogEntryValidator.class.getName());
+
+    /**
+     * Checks that the {@link Log}'s logbooks and tags are valid, i.e. that they exist in Elastic.
+     * @param log The {@link Log} entry to check.
+     * @param context Validation context
+     * @return <code>true</code> if the log entry is considered valid, otherwise <code>false</code>
+     */
+    public boolean isValid(Log log, ConstraintValidatorContext context) {
+        List<String> existingLogbookNames = new ArrayList<>();
+        logbookRepository.findAll().forEach(l -> existingLogbookNames.add(l.getName()));
+        for(Logbook logbook : log.getLogbooks()){
+            if(!existingLogbookNames.contains(logbook.getName())){
+                logger.log(Level.INFO, "Logbook '" + logbook.getName() + "' is invalid.");
+                return false;
+            }
+        }
+
+        List<String> existingTagNames = new ArrayList<>();
+        tagRepository.findAll().forEach(t -> existingTagNames.add(t.getName()));
+        for(Tag tag : log.getTags()){
+            if(!existingTagNames.contains(tag.getName())){
+                logger.log(Level.INFO, "Tag '" + tag.getName() + "' is invalid.");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/phoebus/olog/entity/ValidLog.java
+++ b/src/main/java/org/phoebus/olog/entity/ValidLog.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validation annotation used to validate a {@link Log}.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {LogEntryValidator.class})
+public @interface ValidLog {
+
+    String message() default "Log entry invalid.";
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/org/phoebus/olog/LogResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTest.java
@@ -298,6 +298,67 @@ public class LogResourceTest extends ResourcesTestBase {
     }
 
     @Test
+    public void testUpdateInvalidLogbook() throws Exception {
+
+        Property property1 = new Property();
+        property1.setName("prop1");
+        property1.addAttributes(new Attribute("name1", "value1"));
+
+        Log log = LogBuilder.createLog()
+                .id(2L)
+                .owner("user")
+                .title("title")
+                .withLogbooks(Set.of(new Logbook("invalid", "owner")))
+                .withTags(Set.of(tag1, tag2))
+                .description("description1")
+                .createDate(now)
+                .level("Urgent")
+                .setProperties(Sets.newSet(property1))
+                .build();
+
+        when(logbookRepository.findAll()).thenReturn(Arrays.asList(logbook1, logbook2));
+        when(logRepository.findById("1")).thenReturn(Optional.of(log));
+        when(logRepository.update(log)).thenReturn(log);
+
+        MockHttpServletRequestBuilder request = post("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/1")
+                .content(objectMapper.writeValueAsString(log))
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testUpdateInvalidTag() throws Exception {
+
+        Property property1 = new Property();
+        property1.setName("prop1");
+        property1.addAttributes(new Attribute("name1", "value1"));
+
+        Log log = LogBuilder.createLog()
+                .id(2L)
+                .owner("user")
+                .title("title")
+                .withLogbooks(Set.of(logbook1))
+                .withTags(Set.of(new Tag("invalid")))
+                .description("description1")
+                .createDate(now)
+                .level("Urgent")
+                .setProperties(Sets.newSet(property1))
+                .build();
+
+        when(logbookRepository.findAll()).thenReturn(Arrays.asList(logbook1, logbook2));
+        when(tagRepository.findAll()).thenReturn(Arrays.asList(tag1, tag2));
+        when(logRepository.findById("1")).thenReturn(Optional.of(log));
+        when(logRepository.update(log)).thenReturn(log);
+
+        MockHttpServletRequestBuilder request = post("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/1")
+                .content(objectMapper.writeValueAsString(log))
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void testCreateLogInvalidLogbook() throws Exception {
         Logbook logbook = new Logbook("bad", "owner");
         Log log = LogBuilder.createLog()


### PR DESCRIPTION
The create log endpoint already validates logbook and tag names. The update end point does not.

This PR implements validation the "proper" way for both endpoints.