### PR TITLE
Bug fix and minor change in attachment search

### DIFF
--- a/src/main/resources/static/SearchHelp_en.html
+++ b/src/main/resources/static/SearchHelp_en.html
@@ -113,12 +113,13 @@
 
             <h3>attachments</h3>
             If this added to the search query, the service will return log entries that contain at least one file attachment.
-            The value for this key is <b>case sensitive</b>. If a value for this search parameter is omitted, all attachment types are considered. Using
+            The value for this key is <b>case sensitive</b>. Use <code>attachments=all</code> to search for log entries with attachments of any type.
             <code>attachments=image</code> will match entries with image attachments, while <code>attachments=plt</code>
-            will match entries with plot file attachments. To search for log entries that containing attachments any of type but <code>image</code>
+            will match entries with plot file attachments. To search for log entries that containing attachments any of type besides <code>image</code>
             or <code>plt</code>, use <code>attachments=file</code>.<br>
 
-            As with logbooks and tags, attachment type values can be combined, e.g. <code>attachments=image,plt</code>.
+            As with logbooks and tags, attachment type values can be combined, e.g. <code>attachments=image,plt</code>. If
+            'all' is specified in the value, all other attachment type specifiers are ignored.
 
             <h3>Combining keys</h3>
             If multiple keys are used in a search query, the service will consider all (valid) keys and return log

--- a/src/site/sphinx/index.rst
+++ b/src/site/sphinx/index.rst
@@ -238,6 +238,10 @@ Search Parameters
 +---------------+------------------------------------------------------------------+
 |*logbooks*     | Search for log entries with at least one of the given logbooks   |
 +---------------+------------------------------------------------------------------+
+| **Attachments searches**                                                         |
++---------------+------------------------------------------------------------------+
+|*attachments*  | To search for entries with at least one attachment               |
++---------------+------------------------------------------------------------------+
 | **Pagination searches**                                                          |
 +---------------+------------------------------------------------------------------+
 |*size*         | The number of log entries to be returned within each page        |
@@ -250,9 +254,10 @@ Search Parameters
 |*sort*         | `up|down` order the search results based on create time          |
 +---------------+------------------------------------------------------------------+
 
+
 Example:
 
-**GET** https://localhost:8181/Olog/logs?desc=dump&logbooks=Operations
+**GET** https://localhost:8181/Olog/logs/search?desc=dump&logbooks=Operations
 
 The above search request will return all log entires with the term "dump" in their 
 descriptions and which are part of the Operations logbook.
@@ -260,6 +265,10 @@ descriptions and which are part of the Operations logbook.
 Retrieving an attachment of a log entry
  
 **GET** https://localhost:8181/Olog/logs/attachments/{logId}/{filename}
+
+Find entries with at least one attachment of type 'image'
+
+**GET** https://localhost:8181/Olog/logs/search?attachments=image
 
 
 Managing Logbooks & Tags


### PR DESCRIPTION
To make client implementations simpler, attachments=all is supported to handle search for log entries with attachments of any type.

Also minor documentation addition.