### PR TITLE
POST API support

### DIFF
--- a/src/main/java/org/phoebus/olog/LogResource.java
+++ b/src/main/java/org/phoebus/olog/LogResource.java
@@ -328,10 +328,12 @@ public class LogResource {
             persistedLog.setLevel(log.getLevel());
             persistedLog.setProperties(log.getProperties());
             persistedLog.setModifyDate(Instant.now());
-            persistedLog.setDescription(log.getDescription());
+            persistedLog.setDescription(log.getDescription());   // to make it work with old clients where description field is sent instead of source
+            persistedLog.setSource(log.getSource());
             persistedLog.setTags(log.getTags());
             persistedLog.setLogbooks(log.getLogbooks());
             persistedLog.setTitle(log.getTitle());
+            persistedLog = cleanMarkup(markup, persistedLog);
 
             Log newLogEntry = logRepository.update(persistedLog);
             return newLogEntry;

--- a/src/main/java/org/phoebus/olog/entity/preprocess/impl/CommonmarkCleaner.java
+++ b/src/main/java/org/phoebus/olog/entity/preprocess/impl/CommonmarkCleaner.java
@@ -30,17 +30,20 @@ public class CommonmarkCleaner implements MarkupCleaner {
     private Parser parser = Parser.builder().build();
 
     /**
-     * Processes the log entry under the assumption that the source field of a {@link Log} object
-     * as posted by client can be overwritten, if specified. This method treats the
-     * description field as a Commonmark source and copies it to the source field. Then the same
-     * string is processed to set the description field to a "plain text" variant of the Commonmark source.
+     * Processes the log entry under the assumption that the description field of a {@link Log} object
+     * client can be overwritten. This method treats the source field as a Commonmark source and copies 
+     * it to the description field. Then the same string is processed to set the description field to a 
+     * "plain text" variant of the Commonmark source.
      * @param log The {@link Log} entry to clean of markup.
      * @return The processed log entry.
      */
     @Override
     public Log process(Log log){
-        if(log.getDescription() != null){ // Should not be null, but clients cannot be trusted.
+        if (log.getSource() == null) { // to work with old clients where the source is sent in description field. 
             log.setSource(log.getDescription());
+        }
+        if(log.getSource() != null){ // Should not be null, but clients cannot be trusted.
+            log.setDescription(log.getSource());
             Node document = parser.parse(log.getDescription());
             String plainText = textContentRenderer.render(document);
             log.setDescription(plainText);

--- a/src/test/java/org/phoebus/olog/LogResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTest.java
@@ -228,7 +228,7 @@ public class LogResourceTest extends ResourcesTestBase {
                 .title("title")
                 .withLogbooks(Set.of(logbook1, logbook2))
                 .withTags(Set.of(tag1, tag2))
-                .description("description1")
+                .source("description1")
                 .createDate(now)
                 .modifyDate(now)
                 .level("Urgent")

--- a/src/test/java/org/phoebus/olog/entity/preprocess/CommonmarkPreprocessorTest.java
+++ b/src/test/java/org/phoebus/olog/entity/preprocess/CommonmarkPreprocessorTest.java
@@ -32,8 +32,8 @@ public class CommonmarkPreprocessorTest {
     @Test
     public void testDescriptionNonNull(){
         Log log = LogBuilder.createLog()
-                .description("**BOLD** ![alt](http://foo.bar)")
-                .source(null)
+                .source("**BOLD** ![alt](http://foo.bar)")
+                .description(null)
                 .build();
 
         log = commonmarkPreprocessor.process(log);


### PR DESCRIPTION
As discussed over email:
The update operation should do the same thing as when creating a log entry, i.e. client should send only source, server should process source to populate description

Based on this I made the following changes:
In POST mapping for log entry, applied cleanMarkup to log as is done in PUT mapping.
In CommonmarkCleaner, processed the source field to clean the markup tags and wrote it to description field.
Updated unit tests to match the above changes.
Made sure the server supports the current UI client(web), which sends log entry's source in description field in PUT API.