### PR TITLE
Fix: Docker Compose Fails to Start; no main manifest attribute, in service-olog-2.0.5-SNAPSHOT-javadoc.jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM maven:3.6.3-openjdk-11 AS maven-build
 RUN mkdir phoebus-olog
 WORKDIR /phoebus-olog
 COPY . .
-RUN mvn clean install -DskipTests=true -Pdeployable-jar
+RUN mvn clean install \
+    -DskipTests=true \
+    -Dmaven.javadoc.skip=true \
+    -Dmaven.source.skip=true \
+    -Pdeployable-jar
 
 # Use smaller openjdk image for running.
 FROM openjdk:11


### PR DESCRIPTION
docker-compose fails due to attempting to run javadoc, sources, etc jars instead of app jar. 
So, I've excluded the generation of those jars in the build step so that the run command finds the correct jar. 

Something you may consider is configuring the build step to generate a jar with an explicit name independent from project version, e.g. "app.jar", as I know from prior experience the wildcard features can be inconsistent in some CI plugins/tools versions.

But, I am not sure if you have some other reason for generating all those jars; I'll leave that to you.