### PR TITLE
Fix: HTTP 500 Connection Refused when using Docker Compose development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Ensure that the elastic server is up before starting olog.
     command: >
       /bin/bash -c "
-          while ! curl -s -f elastic:9200/_cluster/health?wait_for_status=green;
+          while ! curl -s -f elastic:9200/_cluster/health?wait_for_status=yellow;
         do
           echo Waiting for Elasticsearch;
           sleep 1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Ensure that the elastic server is up before starting olog.
     command: >
       /bin/bash -c "
-          while ! curl -s -f elastic:9200;
+          while ! curl -s -f elastic:9200/_cluster/health?wait_for_status=green;
         do
           echo Waiting for Elasticsearch;
           sleep 1;
@@ -28,12 +28,14 @@ services:
       - olog-mongodata:/etc/mongo
 
   elastic:
-    image: elasticsearch:6.8.13
+    image: elasticsearch:8.2.3
     environment:
       cluster.name: elasticsearch
       bootstrap.memory_lock: "true"
       discovery.type: single-node
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
     ports:
       - 9200:9200
     volumes:

--- a/src/main/java/org/phoebus/olog/ElasticConfig.java
+++ b/src/main/java/org/phoebus/olog/ElasticConfig.java
@@ -64,6 +64,8 @@ public class ElasticConfig {
     private String host;
     @Value("${elasticsearch.http.port:9200}")
     private int port;
+    @Value("${elasticsearch.http.protocol:https}")
+    private String protocol;
     @Value("${elasticsearch.create.indices:true}")
     private String createIndices;
 
@@ -81,7 +83,7 @@ public class ElasticConfig {
     public ElasticsearchClient getClient() {
         if (client == null) {
             // Create the low-level client
-            RestClient httpClient = RestClient.builder(new HttpHost(host, port)).build();
+            RestClient httpClient = RestClient.builder(new HttpHost(host, port, protocol)).build();
 
             // Create the Java API Client with the same low level client
             ElasticsearchTransport transport = new RestClientTransport(

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -83,6 +83,7 @@ elasticsearch.network.host: elastic
 # Set a custom port to listen for HTTP traffic:
 #
 elasticsearch.http.port: 9200
+elasticsearch.http.protocol: http
 
 # Set the name of the elastic cluster
 elasticsearch.cluster.name: elasticsearch


### PR DESCRIPTION
When starting the docker-compose stack, the services will all appear to have started; however creation of indexes, loading of development data, etc. will all have failed. So, when running the docker integration tests or just trying to GET tags etc via Postman the Java service will respond with HTTP 500 due to the connection being either refused or with a 404 due to search failing to find the expected results.

This is due to (1) starting the olog service before the cluster was fully ready, and (2) security/ssl not correctly disabled for local development. 

NOTE: 
While setting the xpack.security variables in the docker compose environment is sufficient to startup the local cluster with security disabled in development, it is also necessary to specify the protocol as http in the ElasticsearchClient. 

Therefore, I've added the env var `elasticsearch.http.protocol` with a default of `https`. This is overridden in the docker spring profile. So, if you are starting the Java service directly locally but running an elastic cluster separately from docker, you will need to add `elasticsearch.http.protocol=http` to your run configuration.