### PR TITLE
New create log entry endpoint

### DIFF
--- a/src/main/java/org/phoebus/olog/Application.java
+++ b/src/main/java/org/phoebus/olog/Application.java
@@ -1,12 +1,18 @@
 package org.phoebus.olog;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.phoebus.olog.notification.LogEntryNotifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -135,5 +141,4 @@ public class Application {
     public LogEntryValidator logEntryValidator(){
         return new LogEntryValidator();
     }
-
 }

--- a/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
+++ b/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
@@ -18,7 +18,10 @@
 
 package org.phoebus.olog;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -26,18 +29,24 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
+/**
+ * Handles request exceeding configured sizes (spring.servlet.multipart.max-file-size and
+ * spring.servlet.multipart.max-request-size). In such cases client will get an HTTP 413 (payload too large) response
+ * with a (hopefully) useful message.
+ */
 @ControllerAdvice
+@SuppressWarnings("unused")
 public class FileUploadSizeExceededHandler {
 
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Too large")
-    public void handleMaxSizeExceededException(RuntimeException ex, WebRequest request) {
-        System.out.println();
-    }
+    @Value("${spring.servlet.multipart.max-file-size}")
+    private String maxFileSize;
 
-    @ExceptionHandler(MultipartException.class)
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Too large")
-    public void handleMultipartException(RuntimeException ex, WebRequest request) {
-        System.out.println();
+    @Value("${spring.servlet.multipart.max-request-size}")
+    private String maxRequestSize;
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<String> handleMaxSizeExceededException(RuntimeException ex, WebRequest request) {
+        return new ResponseEntity<>("Log entry exceeds size limits: max size per file: " + maxFileSize + ", max total size: " + maxRequestSize,
+                HttpStatus.PAYLOAD_TOO_LARGE);
     }
 }

--- a/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
+++ b/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
+
+@ControllerAdvice
+public class FileUploadSizeExceededHandler {
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Too large")
+    public void handleMaxSizeExceededException(RuntimeException ex, WebRequest request) {
+        System.out.println();
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Too large")
+    public void handleMultipartException(RuntimeException ex, WebRequest request) {
+        System.out.println();
+    }
+}

--- a/src/main/java/org/phoebus/olog/HttpConnectorConfig.java
+++ b/src/main/java/org/phoebus/olog/HttpConnectorConfig.java
@@ -4,7 +4,6 @@ import org.apache.catalina.connector.Connector;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +12,7 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource("classpath:/application.properties")
+@SuppressWarnings("unused")
 public class HttpConnectorConfig {
 
     @Value("${server.http.enable:true}")
@@ -32,7 +32,10 @@ public class HttpConnectorConfig {
         Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
         connector.setScheme("http");
         connector.setPort(port);
-        ((AbstractHttp11Protocol <?>)connector.getProtocolHandler()).setMaxSwallowSize(50 * 1024 * 1024);
+        // This is needed to be able to send a response if client uploads a log entry
+        // exceeding configured max sizes. Without this setting Tomcat will simply close the
+        // connection before a response can be sent.
+        ((AbstractHttp11Protocol <?>)connector.getProtocolHandler()).setMaxSwallowSize(-1);
         return connector;
     }
 }

--- a/src/main/java/org/phoebus/olog/HttpConnectorConfig.java
+++ b/src/main/java/org/phoebus/olog/HttpConnectorConfig.java
@@ -1,8 +1,10 @@
 package org.phoebus.olog;
 
 import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +32,7 @@ public class HttpConnectorConfig {
         Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
         connector.setScheme("http");
         connector.setPort(port);
+        ((AbstractHttp11Protocol <?>)connector.getProtocolHandler()).setMaxSwallowSize(50 * 1024 * 1024);
         return connector;
     }
 }

--- a/src/main/java/org/phoebus/olog/InfoResource.java
+++ b/src/main/java/org/phoebus/olog/InfoResource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.mongodb.client.MongoClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +24,7 @@ import static org.phoebus.olog.OlogResourceDescriptors.OLOG_SERVICE_INFO;
 
 @RestController
 @RequestMapping(OLOG_SERVICE_INFO)
+@SuppressWarnings("unused")
 public class InfoResource
 {
 
@@ -39,6 +41,12 @@ public class InfoResource
     @Value("${elasticsearch.http.port:9200}")
     private int port;
 
+    @Value("${spring.servlet.multipart.max-file-size}")
+    private String maxFileSize;
+
+    @Value("${spring.servlet.multipart.max-request-size}")
+    private String maxRequestSize;
+
     private final static ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
     /**
@@ -48,12 +56,12 @@ public class InfoResource
     @GetMapping
     public String info() {
 
-        Map<String, Object> ologServiceInfo = new LinkedHashMap<String, Object>();
+        Map<String, Object> ologServiceInfo = new LinkedHashMap<>();
         ologServiceInfo.put("name", "Olog Service");
         ologServiceInfo.put("version", version);
 
         ElasticsearchClient client = esService.getClient();
-        Map<String, String> elasticInfo = new LinkedHashMap<String, String>();
+        Map<String, String> elasticInfo = new LinkedHashMap<>();
         try {
             InfoResponse response = client.info();
             elasticInfo.put("status", "Connected");
@@ -70,6 +78,12 @@ public class InfoResource
         ologServiceInfo.put("elastic", elasticInfo);
         ologServiceInfo.put("mongoDB", mongoClient.getClusterDescription().getShortDescription());
 
+        Map<String, Object> serverConfigInfo = new LinkedHashMap<>();
+        // Provide sizes in MB, arithmetics needed to avoid rounding to 0.
+        serverConfigInfo.put("Max file size", 1.0 * DataSize.parse(maxFileSize).toKilobytes() / 1024);
+        serverConfigInfo.put("Max request size", 1.0 * DataSize.parse(maxRequestSize).toKilobytes() / 1024);
+
+        ologServiceInfo.put("server config", serverConfigInfo);
 
         try {
             return objectMapper.writeValueAsString(ologServiceInfo);
@@ -78,5 +92,4 @@ public class InfoResource
             return "Failed to gather Olog service info";
         }
     }
-
 }

--- a/src/main/java/org/phoebus/olog/entity/Attachment.java
+++ b/src/main/java/org/phoebus/olog/entity/Attachment.java
@@ -24,6 +24,10 @@ public class Attachment
     @JsonIgnore
     private InputStreamSource attachment;
 
+    private String checksum;
+
+
+
     /**
      * Creates a new instance of Attachment.
      */
@@ -138,5 +142,13 @@ public class Attachment
     public void setFileMetadataDescription(String fileMetadataDescription)
     {
         this.fileMetadataDescription = fileMetadataDescription;
+    }
+
+    public String getChecksum() {
+        return checksum;
+    }
+
+    public void setChecksum(String checksum) {
+        this.checksum = checksum;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -138,9 +138,10 @@ mongo.port:27017
 # with the origin(s) on which the web front-end is deployed.
 #cors.allowed.origins=http://localhost:3000
 
-################## File upload and request size limits ##################
-spring.servlet.multipart.max-file-size=50MB
-spring.servlet.multipart.max-request-size=100MB
+################## File upload and request size limits ####################
+# Unit should be MB (or KB), it is case-sensitive! Invalid unit will inhibit server startup.
+spring.servlet.multipart.max-file-size=15MB
+spring.servlet.multipart.max-request-size=50MB
 
 ################## List of "levels" ##################
 levels=Urgent,Suggestion,Info,Request,Problem
@@ -178,3 +179,4 @@ spring.mvc.static-path-pattern=/Olog/**
 default.logbook.url=
 default.tags.url=
 default.properties.url=
+


### PR DESCRIPTION
To summarize:

- Proper handling of oversized request, i.e. due to large attachment(s).
- New endpoint (PUT /Olog/logs/multipart) accepting both log entry and optional attachment files.

Application property ```spring.servlet.multipart.max-file-size``` sets the limit for single file size.
Application property ```spring.servlet.multipart.max-request-size``` sets the limit for the total size of the request. This would handle the case of multiple attachments each below the single file size limit, but with an unacceptable total size.

Clients must be updated. Have verified on both Phoebus client and web client. Update Phoebus client available in Phoebus project on branch CSSTUDIO-1818.

Backwards compatible with current clients.