### PR TITLE
add socket and connect timeout config

### DIFF
--- a/src/main/java/org/phoebus/olog/ElasticConfig.java
+++ b/src/main/java/org/phoebus/olog/ElasticConfig.java
@@ -140,7 +140,6 @@ public class ElasticConfig {
                             // Avoid timeout problems
                             // https://github.com/elastic/elasticsearch/issues/65213
                             builder.setKeepAliveStrategy((response, context) -> ES_HTTP_CLIENT_KEEP_ALIVE_TIMEOUT_MS)
-                                    .setConnectionTimeToLive(5, TimeUnit.MINUTES)
                     )
                     .build();
 


### PR DESCRIPTION
Adds socket and connect timeout configuration, see https://github.com/elastic/elasticsearch/issues/65213
(sorry about the number of PRs for this -- it's difficult to test/force a timeout locally, so it has been a bit of stabbing in the dark)

```
elasticsearch.http.connect_timeout_ms
elasticsearch.http.socket_timeout_ms
```