### PR TITLE
CSSTUDIO-2026: add openapi/swagger + javadoc fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <elasticsearch.version>8.2.0</elasticsearch.version>
         <lombok.version>1.18.16</lombok.version>
         <junit.version>5.8.2</junit.version>
+        <springdoc.version>1.6.10</springdoc.version>
         <skipITs>true</skipITs>
         <skipITCoverage>true</skipITCoverage>
         <jacoco.skip>true</jacoco.skip>
@@ -111,6 +112,18 @@
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <version>2.0.1</version>
+        </dependency>
+
+        <!-- OpenAPI / Swagger UI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-security</artifactId>
+            <version>${springdoc.version}</version>
         </dependency>
 
         <dependency>
@@ -363,7 +376,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <elasticsearch.version>8.2.0</elasticsearch.version>
         <lombok.version>1.18.16</lombok.version>
         <junit.version>5.8.2</junit.version>
-        <springdoc.version>1.6.10</springdoc.version>
+        <springdoc.version>1.7.0</springdoc.version>
         <skipITs>true</skipITs>
         <skipITCoverage>true</skipITCoverage>
         <jacoco.skip>true</jacoco.skip>
@@ -118,11 +118,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>${springdoc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-security</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -183,3 +183,10 @@ default.logbook.url=
 default.tags.url=
 default.properties.url=
 
+########### OpenAPI / Swagger #############
+#OPENAPI
+openapi.server=${OPENAPI_SERVER:http://localhost:8080}
+springdoc.api-docs.path=${API_PATH:/api/spec}
+springdoc.swagger-ui.path=${SWAGGER_PATH:/api/docs}
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.displayOperationId=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -185,7 +185,6 @@ default.properties.url=
 
 ########### OpenAPI / Swagger #############
 #OPENAPI
-openapi.server=${OPENAPI_SERVER:http://localhost:8080}
 springdoc.api-docs.path=${API_PATH:/api/spec}
 springdoc.swagger-ui.path=${SWAGGER_PATH:/api/docs}
 springdoc.swagger-ui.disable-swagger-default-url=true


### PR DESCRIPTION
Changes:

- Adds support for openapi/swagger autogenerated API docs 
  - UI available at at http://localhost:8080/api/docs 
  - JSON available at http://localhost:8080/api/spec
  - Uses the autogenerated docs as-is; does not currently add additional annotations to the swagger docs to e.g. name resources, use tags, etc
  - Shows operation ids (generated from controller method names, or disambiguated if there are duplicates)

Fixes:

- upgrades maven-javadoc-plugin to fix MJAVADOC-650 for Java 9+

<img width="1500" alt="Screenshot 2024-01-03 at 09 52 55" src="https://github.com/Olog/phoebus-olog/assets/77395846/3c2e6c34-6709-43ef-841c-c7a9c047994f">


