### PR TITLE
fix: set host vars in docker compose

### DIFF
--- a/docker-compose-integrationtest.yml
+++ b/docker-compose-integrationtest.yml
@@ -17,6 +17,8 @@ services:
       embedded_ldap.enabled: "false"
       demo_auth.enabled: "true"
       skipITCoverage: "true"
+      mongo.host: mongo
+      elasticsearch.network.host: elastic
     command: >
       /bin/bash -c "
           while ! curl -s -f elastic:9200/_cluster/health?wait_for_status=yellow;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - mongo
       - elastic
     environment:
-      cors.allowed.origins: http://localhost:3000
       mongo.host: mongo
       elasticsearch.network.host: elastic
     # Ensure that the elastic server is up before starting olog.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     depends_on:
       - mongo
       - elastic
+    environment:
+      cors.allowed.origins: http://localhost:3000
+      mongo.host: mongo
+      elasticsearch.network.host: elastic
     # Ensure that the elastic server is up before starting olog.
     command: >
       /bin/bash -c "


### PR DESCRIPTION
When starting the ecosystem / services with docker compose, the backend fails to communicate with elastic and mongo db.
 
This is because in the compose networking environment the service hosts are the names of the services (elastic, mongo, etc) rather than localhost. 

This fixes that configuration issue for local development, and also adds localhost:3000 as an allowed cors origin so that local frontend development can speak to the server as well. 