### PR TITLE
Move "levels" definition to service

### DIFF
--- a/src/main/java/org/phoebus/olog/AttachmentRepository.java
+++ b/src/main/java/org/phoebus/olog/AttachmentRepository.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -144,8 +145,9 @@ public class AttachmentRepository implements CrudRepository<Attachment, String> 
 
     @Override
     public void deleteAllById(Iterable ids) {
-        while (ids.iterator().hasNext()) {
-            deleteById((String) ids.iterator().next());
+        Iterator<String> iterator = ids.iterator();
+        while (iterator.hasNext()) {
+            deleteById(iterator.next());
         }
     }
 }

--- a/src/main/java/org/phoebus/olog/LevelRepository.java
+++ b/src/main/java/org/phoebus/olog/LevelRepository.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2010-2020 Brookhaven National Laboratory
- * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
- * All rights reserved. Use is subject to license terms and conditions.
+/**
+ * Copyright (C) 2025 European Spallation Source ERIC.
  */
 package org.phoebus.olog;
 

--- a/src/main/java/org/phoebus/olog/LevelRepository.java
+++ b/src/main/java/org/phoebus/olog/LevelRepository.java
@@ -36,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,7 +58,6 @@ public class LevelRepository implements CrudRepository<org.phoebus.olog.entity.L
     @Autowired
     @Qualifier("client")
     ElasticsearchClient client;
-
     /**
      *
      */
@@ -236,8 +236,9 @@ public class LevelRepository implements CrudRepository<org.phoebus.olog.entity.L
 
     @Override
     public void deleteAllById(Iterable ids) {
-        while (ids.iterator().hasNext()) {
-            deleteById((String) ids.iterator().next());
+        Iterator<String> iterator = ids.iterator();
+        while (iterator.hasNext()) {
+            deleteById(iterator.next());
         }
     }
 }

--- a/src/main/java/org/phoebus/olog/LevelRepository.java
+++ b/src/main/java/org/phoebus/olog/LevelRepository.java
@@ -29,6 +29,7 @@ import co.elastic.clients.elasticsearch.core.mget.MultiGetResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
@@ -50,6 +51,10 @@ import static org.phoebus.olog.ElasticConfig.ES_LEVEL_INDEX;
 public class LevelRepository implements CrudRepository<org.phoebus.olog.entity.Level, String> {
 
     private final Logger logger = Logger.getLogger(LevelRepository.class.getName());
+
+    @SuppressWarnings("unused")
+    @Value("${elasticsearch.result.size.levels:100}")
+    private int levelsResultSize;
 
     @Autowired
     @Qualifier("client")
@@ -158,7 +163,7 @@ public class LevelRepository implements CrudRepository<org.phoebus.olog.entity.L
                     s.index(ES_LEVEL_INDEX)
                             .query(new MatchAllQuery.Builder().build()._toQuery())
                             .timeout("10s")
-                            .size(1000));
+                            .size(levelsResultSize));
 
             SearchResponse<org.phoebus.olog.entity.Level> response =
                     client.search(searchRequest, org.phoebus.olog.entity.Level.class);

--- a/src/main/java/org/phoebus/olog/LevelRepository.java
+++ b/src/main/java/org/phoebus/olog/LevelRepository.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2010-2020 Brookhaven National Laboratory
+ * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
+ * All rights reserved. Use is subject to license terms and conditions.
+ */
+package org.phoebus.olog;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.Result;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.DeleteRequest;
+import co.elastic.clients.elasticsearch.core.DeleteResponse;
+import co.elastic.clients.elasticsearch.core.ExistsRequest;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
+import co.elastic.clients.elasticsearch.core.MgetRequest;
+import co.elastic.clients.elasticsearch.core.MgetResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import co.elastic.clients.elasticsearch.core.mget.MultiGetResponseItem;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import static org.phoebus.olog.ElasticConfig.ES_LEVEL_INDEX;
+
+@Repository
+public class LevelRepository implements CrudRepository<org.phoebus.olog.entity.Level, String> {
+
+    private final Logger logger = Logger.getLogger(LevelRepository.class.getName());
+
+    @Autowired
+    @Qualifier("client")
+    ElasticsearchClient client;
+
+    /**
+     *
+     */
+    @Override
+    public <S extends org.phoebus.olog.entity.Level> S save(S level) {
+        try {
+            IndexRequest<org.phoebus.olog.entity.Level> indexRequest =
+                    IndexRequest.of(i ->
+                            i.index(ES_LEVEL_INDEX)
+                                    .id(level.name())
+                                    .document(level)
+                                    .refresh(Refresh.True));
+            IndexResponse response = client.index(indexRequest);
+
+            if (response.result().equals(Result.Created) ||
+                    response.result().equals(Result.Updated)) {
+                GetRequest getRequest =
+                        GetRequest.of(g ->
+                                g.index(ES_LEVEL_INDEX).id(response.id()));
+                GetResponse<org.phoebus.olog.entity.Level> resp =
+                        client.get(getRequest, org.phoebus.olog.entity.Level.class);
+                return (S) resp.source();
+            }
+            return null;
+        } catch (Exception e) {
+            String message = MessageFormat.format(TextUtil.LEVELS_NOT_CREATED, level.name());
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message);
+        }
+    }
+
+    @Override
+    public <S extends org.phoebus.olog.entity.Level> Iterable<S> saveAll(Iterable<S> levels) {
+        List<BulkOperation> bulkOperations = new ArrayList<>();
+        levels.forEach(level -> bulkOperations.add(IndexOperation.of(i ->
+                i.index(ES_LEVEL_INDEX).document(level).id(level.name()))._toBulkOperation()));
+        BulkRequest bulkRequest =
+                BulkRequest.of(r ->
+                        r.operations(bulkOperations).refresh(Refresh.True));
+
+        BulkResponse bulkResponse;
+        try {
+            bulkResponse = client.bulk(bulkRequest);
+            if (bulkResponse.errors()) {
+                // process failures by iterating through each bulk response item
+                bulkResponse.items().forEach(responseItem -> {
+                    if (responseItem.error() != null) {
+                        logger.log(Level.SEVERE, responseItem.error().reason());
+                    }
+                });
+                String message = MessageFormat.format(TextUtil.LEVELS_NOT_CREATED, levels);
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message);
+            } else {
+                return levels;
+            }
+        } catch (IOException e) {
+            String message = MessageFormat.format(TextUtil.LEVELS_NOT_CREATED, levels);
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message);
+        }
+    }
+
+    @Override
+    public Optional<org.phoebus.olog.entity.Level> findById(String levelName) {
+        try {
+            GetRequest getRequest =
+                    GetRequest.of(g ->
+                            g.index(ES_LEVEL_INDEX).id(levelName));
+            GetResponse<org.phoebus.olog.entity.Level> resp =
+                    client.get(getRequest, org.phoebus.olog.entity.Level.class);
+            if (resp.found()) {
+                return Optional.of(resp.source());
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            String message = MessageFormat.format(TextUtil.LEVEL_NOT_FOUND, levelName);
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, message);
+        }
+    }
+
+    @Override
+    public boolean existsById(String levelName) {
+        try {
+            ExistsRequest.Builder builder = new ExistsRequest.Builder();
+            builder.index(ES_LEVEL_INDEX).id(levelName);
+            return client.exists(builder.build()).value();
+        } catch (ElasticsearchException | IOException e) {
+            String message = MessageFormat.format(TextUtil.LEVEL_EXISTS_FAILED, levelName);
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message, null);
+        }
+    }
+
+    @Override
+    public Iterable<org.phoebus.olog.entity.Level> findAll() {
+
+        try {
+            SearchRequest searchRequest = SearchRequest.of(s ->
+                    s.index(ES_LEVEL_INDEX)
+                            .query(new MatchAllQuery.Builder().build()._toQuery())
+                            .timeout("10s")
+                            .size(1000));
+
+            SearchResponse<org.phoebus.olog.entity.Level> response =
+                    client.search(searchRequest, org.phoebus.olog.entity.Level.class);
+
+            return response.hits().hits().stream().map(Hit::source).collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, TextUtil.LEVEL_NOT_FOUND, e);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, TextUtil.LEVEL_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public Iterable<org.phoebus.olog.entity.Level> findAllById(Iterable<String> levelNames) {
+
+        List<String> ids = new ArrayList<>();
+        levelNames.forEach(ids::add);
+        MgetRequest mgetRequest = MgetRequest.of(r -> r.index(ES_LEVEL_INDEX).ids(ids));
+        try {
+            List<org.phoebus.olog.entity.Level> foundLevels = new ArrayList<>();
+            MgetResponse<org.phoebus.olog.entity.Level> resp =
+                    client.mget(mgetRequest, org.phoebus.olog.entity.Level.class);
+            for (MultiGetResponseItem<org.phoebus.olog.entity.Level> multiGetResponseItem : resp.docs()) {
+                if (!multiGetResponseItem.isFailure()) {
+                    foundLevels.add(multiGetResponseItem.result().source());
+                }
+            }
+            return foundLevels;
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, TextUtil.LEVELS_NOT_FOUND, e);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, TextUtil.LEVEL_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public long count() {
+        AtomicInteger count = new AtomicInteger();
+        findAll().forEach(l -> count.incrementAndGet());
+        return count.get();
+    }
+
+    @Override
+    public void deleteById(String levelName) {
+        try {
+            DeleteRequest deleteRequest = DeleteRequest.of(d ->
+                    d.index(ES_LEVEL_INDEX).id(levelName).refresh(Refresh.True));
+            DeleteResponse deleteResponse = client.delete(deleteRequest);
+            if (deleteResponse.result().equals(Result.Deleted)) {
+                logger.log(Level.INFO, MessageFormat.format(TextUtil.LEVEL_DELETED, levelName));
+            } else {
+                logger.log(Level.INFO, MessageFormat.format(TextUtil.LEVEL_NOT_DELETED, levelName));
+            }
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, MessageFormat.format(TextUtil.LEVEL_NOT_DELETED, levelName), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(org.phoebus.olog.entity.Level level) {
+        deleteById(level.name());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends org.phoebus.olog.entity.Level> levels) {
+        levels.forEach(level -> deleteById(level.name()));
+    }
+
+    @Override
+    public void deleteAll() {
+        findAll().forEach(l -> delete(l));
+    }
+
+    @Override
+    public void deleteAllById(Iterable ids) {
+        while (ids.iterator().hasNext()) {
+            deleteById((String) ids.iterator().next());
+        }
+    }
+}

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2010-2020 Brookhaven National Laboratory
+ * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
+ * All rights reserved. Use is subject to license terms and conditions.
+ */
+package org.phoebus.olog;
+
+import org.phoebus.olog.entity.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.phoebus.olog.OlogResourceDescriptors.TAG_RESOURCE_URI;
+
+/**
+ * Resource for handling the requests to ../tags
+ * @author Kunal Shroff
+ *
+ */
+@RestController
+@RequestMapping(TAG_RESOURCE_URI)
+public class LevelsResource {
+
+    private Logger log = Logger.getLogger(LevelsResource.class.getName());
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    /** Creates a new instance of TagsResource */
+    public LevelsResource() {
+    }
+
+    /**
+     * GET method for retrieving the list of tags in the database.
+     *
+     * @return list of tags
+     */
+    @GetMapping
+    public Iterable<Tag> findAll() {
+        return tagRepository.findAll();
+    }
+
+    /**
+     * Get method for retrieving the tag with name matching tagName
+     *
+     * @param tagName - the name of the tag to be retrieved
+     * @return the matching tag, or null
+     */
+    @GetMapping("/{tagName}")
+    public Tag findByTitle(@PathVariable String tagName) {
+        Optional<Tag> foundTag = tagRepository.findById(tagName);
+        if (foundTag.isPresent()) {
+            return foundTag.get();
+        } else {
+            String message = MessageFormat.format(TextUtil.TAG_NOT_FOUND, tagName);
+            log.log(Level.SEVERE, message, new ResponseStatusException(HttpStatus.NOT_FOUND));
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, message);
+        }
+    }
+
+    /**
+     * PUT method for creating a tag.
+     *
+     * @param tagName - the name of the tag to be created
+     * @param tag - the tag object with owner and state information
+     * @return the created tag
+     */
+    @PutMapping("/{tagName}")
+    public Tag createTag(@PathVariable String tagName, @RequestBody final Tag tag) {
+        // TODO Check permissions
+        // Validate
+
+        // Validate request parameters
+        validateTagRequest(tag);
+
+        // check if present
+        Optional<Tag> existingTag = tagRepository.findById(tagName);
+        if (existingTag.isPresent()) {
+            // delete existing tag
+            tagRepository.deleteById(tagName);
+        }
+
+        // create new tag
+        return tagRepository.save(tag);
+    }
+
+    /**
+     * PUT method for the tags resource to support the creation of a list of tags
+     *
+     * @param tags - the list of tags to be created
+     * @return the list of tags created
+     */
+    @PutMapping
+    public Iterable<Tag> updateTag(@RequestBody final List<Tag> tags) {
+        // TODO Check permissions
+        // Validate
+
+        // Validate request parameters
+        validateTagRequest(tags);
+
+        // delete existing tags
+        for(Tag tag: tags) {
+            if(tagRepository.existsById(tag.getName())) {
+                // delete existing tag
+                tagRepository.deleteById(tag.getName());
+            }
+        }
+
+        // create new tags
+        return tagRepository.saveAll(tags);
+    }
+
+    @DeleteMapping("/{tagName}")
+    public void deleteTag(@PathVariable String tagName) {
+        // TODO Check permissions
+
+        // check if present
+        Optional<Tag> existingTag = tagRepository.findById(tagName);
+        if (existingTag.isPresent()) {
+            // delete existing tag
+            tagRepository.deleteById(tagName);
+        } else {
+            String message = MessageFormat.format(TextUtil.TAG_NOT_EXISTS, tagName);
+            log.log(Level.SEVERE, message, new ResponseStatusException(HttpStatus.NOT_FOUND));
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, message);
+        }
+    }
+
+    /**
+     * Checks if all the tags included satisfy the following conditions:
+     *
+     * <ol>
+     * <li> the tag names are not null or empty
+     * <li> no validation for tag states
+     * </ol>
+     *
+     * @param tags the tags to be validated
+     */
+    public void validateTagRequest(Iterable<Tag> tags) {
+        for (Tag tag : tags) {
+            validateTagRequest(tag);
+        }
+    }
+
+    /**
+     * Checks if the tag satisfies the following conditions:
+     *
+     * <ol>
+     * <li> the tag name is not null or empty
+     * <li> no validation for tag state
+     * </ol>
+     *
+     * @param tag the tag to be validated
+     */
+    public void validateTagRequest(Tag tag) {
+        if (tag.getName() == null || tag.getName().isEmpty()) {
+            String message = MessageFormat.format(TextUtil.TAG_NAME_CANNOT_BE_NULL_OR_EMPTY, tag.toString());
+            log.log(Level.SEVERE, message, new ResponseStatusException(HttpStatus.BAD_REQUEST));
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message, null);
+        }
+    }
+
+}

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.text.MessageFormat;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -165,8 +166,9 @@ public class LevelsResource {
         }
         Iterable<org.phoebus.olog.entity.Level> existing =
                 levelRepository.findAll();
-        while (existing.iterator().hasNext()) {
-            org.phoebus.olog.entity.Level l = existing.iterator().next();
+        Iterator<org.phoebus.olog.entity.Level> iterator = existing.iterator();
+        while (iterator.hasNext()) {
+            org.phoebus.olog.entity.Level l = iterator.next();
             if (l.defaultLevel() && level.defaultLevel()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         MessageFormat.format(TextUtil.DEFAULT_LEVEL_ALREADY_EXISTS, l.name()));

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -58,7 +58,7 @@ public class LevelsResource {
      */
     @SuppressWarnings("unused")
     @GetMapping("/{levelName}")
-    public org.phoebus.olog.entity.Level findByName(@PathVariable String levelName) {
+    public org.phoebus.olog.entity.Level findById(@PathVariable String levelName) {
         Optional<org.phoebus.olog.entity.Level> foundLevel = levelRepository.findById(levelName);
         if (foundLevel.isPresent()) {
             return foundLevel.get();

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -153,7 +153,7 @@ public class LevelsResource {
 
     /**
      * Validates a {@link org.phoebus.olog.entity.Level}: name must be non-empty. If
-     * {@link org.phoebus.olog.entity.Level#defaultLevel()} is true, then no other
+     * {@link org.phoebus.olog.entity.Level#defaultLevel()} ()} is true, then no other
      * exsting {@link org.phoebus.olog.entity.Level} must be flagged as default.
      *
      * @param level {@link org.phoebus.olog.entity.Level} to add.

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2010-2020 Brookhaven National Laboratory
- * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
- * All rights reserved. Use is subject to license terms and conditions.
+/**
+ * Copyright (C) 2025 European Spallation Source ERIC.
  */
 package org.phoebus.olog;
 
@@ -29,6 +27,7 @@ import static org.phoebus.olog.OlogResourceDescriptors.LEVEL_RESOURCE_RUI;
  *
  * @author Georg Weiss
  */
+@SuppressWarnings("unused")
 @RestController
 @RequestMapping(LEVEL_RESOURCE_RUI)
 public class LevelsResource {

--- a/src/main/java/org/phoebus/olog/LevelsResource.java
+++ b/src/main/java/org/phoebus/olog/LevelsResource.java
@@ -35,11 +35,12 @@ public class LevelsResource {
 
     private final Logger log = Logger.getLogger(LevelsResource.class.getName());
 
+    @SuppressWarnings("unused")
     @Autowired
     private LevelRepository levelRepository;
 
     /**
-     * GET method for retrieving the list of levels in the database.
+     * GET method for retrieving the list of {@link org.phoebus.olog.entity.Level}s in the database.
      *
      * @return list of {@link org.phoebus.olog.entity.Level}s
      */
@@ -49,17 +50,18 @@ public class LevelsResource {
     }
 
     /**
-     * Get method for retrieving the level with name matching levelName
+     * Get method for retrieving the {@link org.phoebus.olog.entity.Level} with name matching levelName
      *
-     * @param levelName - the name of the level to be retrieved
+     * @param levelName - the name of the {@link org.phoebus.olog.entity.Level} to be retrieved
      * @return the matching {@link org.phoebus.olog.entity.Level}. If not
-     * found, HTTP 404 reponse is triggered.
+     * found, HTTP 404 response is triggered.
      */
+    @SuppressWarnings("unused")
     @GetMapping("/{levelName}")
-    public org.phoebus.olog.entity.Level findByTitle(@PathVariable String levelName) {
-        Optional<org.phoebus.olog.entity.Level> foundTag = levelRepository.findById(levelName);
-        if (foundTag.isPresent()) {
-            return foundTag.get();
+    public org.phoebus.olog.entity.Level findByName(@PathVariable String levelName) {
+        Optional<org.phoebus.olog.entity.Level> foundLevel = levelRepository.findById(levelName);
+        if (foundLevel.isPresent()) {
+            return foundLevel.get();
         } else {
             String message = MessageFormat.format(TextUtil.LEVEL_NOT_FOUND, levelName);
             log.log(Level.SEVERE, message, new ResponseStatusException(HttpStatus.NOT_FOUND));
@@ -70,10 +72,18 @@ public class LevelsResource {
     /**
      * PUT method for creating a {@link org.phoebus.olog.entity.Level}.
      *
-     * @param levelName - the name of the tag to be created
-     * @param level     - the {@link org.phoebus.olog.entity.Level} object with owner and state information
-     * @return the created tag
+     * <p>
+     *     If the specified {@link org.phoebus.olog.entity.Level} is marked as default,
+     *     checks are made to make sure no existing {@link org.phoebus.olog.entity.Level}
+     *     in the database is marked as default. This is needed to ensure that only one
+     *     {@link org.phoebus.olog.entity.Level} is defined to be the default.
+     * </p>
+     *
+     * @param levelName - the name of the {@link org.phoebus.olog.entity.Level} to be created
+     * @param level     - the {@link org.phoebus.olog.entity.Level} object, optionally specifying it
+     *                  is the default {@link org.phoebus.olog.entity.Level}.
      */
+    @SuppressWarnings("unused")
     @PutMapping("/{levelName}")
     public org.phoebus.olog.entity.Level createLevel(@PathVariable String levelName, @RequestBody final org.phoebus.olog.entity.Level level) {
 
@@ -81,10 +91,10 @@ public class LevelsResource {
         validateLevelRequest(level);
 
         // check if present
-        Optional<org.phoebus.olog.entity.Level> existingTag =
+        Optional<org.phoebus.olog.entity.Level> existingLevel =
                 levelRepository.findById(levelName);
-        if (existingTag.isPresent()) {
-            // delete existing tag
+        if (existingLevel.isPresent()) {
+            // delete existing level
             levelRepository.deleteById(levelName);
         }
 
@@ -93,13 +103,15 @@ public class LevelsResource {
     }
 
     /**
-     * PUT method for the level resource to support the creation of a list of levels
+     * PUT method for the {@link org.phoebus.olog.entity.Level} resource to support the creation
+     * of a list of {@link org.phoebus.olog.entity.Level}s
      *
-     * @param levels - the list of levels to be created
-     * @return the list of levels created
+     * @param levels - the list of {@link org.phoebus.olog.entity.Level}s to be created
+     * @return the list of {@link org.phoebus.olog.entity.Level}s created
      */
+    @SuppressWarnings("unused")
     @PutMapping
-    public Iterable<org.phoebus.olog.entity.Level> updateTag(@RequestBody final List<org.phoebus.olog.entity.Level> levels) {
+    public Iterable<org.phoebus.olog.entity.Level> createLevels(@RequestBody final List<org.phoebus.olog.entity.Level> levels) {
 
         // Validate request parameters
         validateLevelsRequest(levels);
@@ -112,13 +124,13 @@ public class LevelsResource {
             }
         }
 
-        // create new tags
+        // create new levels
         return levelRepository.saveAll(levels);
     }
 
+    @SuppressWarnings("unused")
     @DeleteMapping("/{levelName}")
-    public void deleteTag(@PathVariable String levelName) {
-        // TODO Check permissions
+    public void deleteLevel(@PathVariable String levelName) {
 
         // check if present
         Optional<org.phoebus.olog.entity.Level> existingLevel = levelRepository.findById(levelName);

--- a/src/main/java/org/phoebus/olog/LogRepository.java
+++ b/src/main/java/org/phoebus/olog/LogRepository.java
@@ -40,6 +40,7 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -302,8 +303,9 @@ public class LogRepository implements CrudRepository<Log, String> {
 
     @Override
     public void deleteAllById(Iterable ids) {
-        while (ids.iterator().hasNext()) {
-            deleteById((String) ids.iterator().next());
+        Iterator<String> iterator = ids.iterator();
+        while (iterator.hasNext()) {
+            deleteById(iterator.next());
         }
     }
 }

--- a/src/main/java/org/phoebus/olog/LogTemplateRepository.java
+++ b/src/main/java/org/phoebus/olog/LogTemplateRepository.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2010-2020 Brookhaven National Laboratory
- * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
- * All rights reserved. Use is subject to license terms and conditions.
+/**
+ * Copyright (C) 2025 European Spallation Source ERIC.
  */
 package org.phoebus.olog;
 

--- a/src/main/java/org/phoebus/olog/LogTemplateResource.java
+++ b/src/main/java/org/phoebus/olog/LogTemplateResource.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2010-2020 Brookhaven National Laboratory
- * Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
- * All rights reserved. Use is subject to license terms and conditions.
+/**
+ * Copyright (C) 2025 European Spallation Source ERIC.
  */
 package org.phoebus.olog;
 

--- a/src/main/java/org/phoebus/olog/LogbookRepository.java
+++ b/src/main/java/org/phoebus/olog/LogbookRepository.java
@@ -53,7 +53,7 @@ import static org.phoebus.olog.ElasticConfig.ES_LOGBOOK_INDEX;
 public class LogbookRepository implements CrudRepository<Logbook, String> {
 
     @SuppressWarnings("unused")
-    @Value("${elasticsearch.result.size.logbooks:10}")
+    @Value("${elasticsearch.result.size.logbooks:100}")
     private int logbooksResultSize;
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
+++ b/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
@@ -15,4 +15,5 @@ public class OlogResourceDescriptors
     static final String ATTACHMENT_URI = OLOG_SERVICE + "/attachment";
     static final String HELP_URI = OLOG_SERVICE + "/help";
     public static final String LOG_TEMPLATE_RESOURCE_URI = OLOG_SERVICE + "/templates";
+    public static final String LEVEL_RESOURCE_RUI = OLOG_SERVICE + "/levels";
 }

--- a/src/main/java/org/phoebus/olog/PropertyRepository.java
+++ b/src/main/java/org/phoebus/olog/PropertyRepository.java
@@ -57,7 +57,7 @@ import static org.phoebus.olog.ElasticConfig.ES_PROPERTY_INDEX;
 public class PropertyRepository implements CrudRepository<Property, String> {
 
     @SuppressWarnings("unused")
-    @Value("${elasticsearch.result.size.properties:10}")
+    @Value("${elasticsearch.result.size.properties:100}")
     private int propertiesResultSize;
 
     @Autowired

--- a/src/main/java/org/phoebus/olog/TagRepository.java
+++ b/src/main/java/org/phoebus/olog/TagRepository.java
@@ -55,7 +55,7 @@ public class TagRepository implements CrudRepository<Tag, String> {
     private final Logger logger = Logger.getLogger(TagRepository.class.getName());
 
     @SuppressWarnings("unused")
-    @Value("${elasticsearch.result.size.tags:10}")
+    @Value("${elasticsearch.result.size.tags:100}")
     private int tagsResultSize;
 
     @Autowired

--- a/src/main/java/org/phoebus/olog/TextUtil.java
+++ b/src/main/java/org/phoebus/olog/TextUtil.java
@@ -154,6 +154,8 @@ public class TextUtil {
     public static final String LEVEL_DELETED                            = "Level {0} deleted";
     public static final String LEVEL_NOT_DELETED                        = "Failed to delete level {0}";
     public static final String LEVELS_DELETE_ALL_NOT_ALLOWED            = "Deleting all levels not allowed";
+    public static final String LEVEL_NAME_CANNOT_BE_NULL_OR_EMPTY       = "The level name cannot be null or empty";
+    public static final String DEFAULT_LEVEL_ALREADY_EXISTS             = "Level {0} alrready defined as default";
     /**
      * This class is not to be instantiated.
      */

--- a/src/main/java/org/phoebus/olog/TextUtil.java
+++ b/src/main/java/org/phoebus/olog/TextUtil.java
@@ -155,7 +155,7 @@ public class TextUtil {
     public static final String LEVEL_NOT_DELETED                        = "Failed to delete level {0}";
     public static final String LEVELS_DELETE_ALL_NOT_ALLOWED            = "Deleting all levels not allowed";
     public static final String LEVEL_NAME_CANNOT_BE_NULL_OR_EMPTY       = "The level name cannot be null or empty";
-    public static final String DEFAULT_LEVEL_ALREADY_EXISTS             = "Level {0} alrready defined as default";
+    public static final String DEFAULT_LEVEL_ALREADY_EXISTS             = "Level {0} already defined as default";
     /**
      * This class is not to be instantiated.
      */

--- a/src/main/java/org/phoebus/olog/TextUtil.java
+++ b/src/main/java/org/phoebus/olog/TextUtil.java
@@ -142,12 +142,18 @@ public class TextUtil {
     public static final String TAG_NOT_CREATED                          = "Failed to create tag {0}";
     public static final String TAG_NOT_DELETED                          = "Failed to delete tag {0}";
     public static final String TAG_NOT_FOUND                            = "Failed to find tag {0}";
+    public static final String LEVEL_NOT_FOUND                          = "Failed to find level {0}";
+    public static final String LEVEL_EXISTS_FAILED                      = "Failed to check if level {0} exists";
 
     public static final String TAGS_DELETE_ALL_NOT_ALLOWED              = "Deleting all tags is not allowed";
     public static final String TAGS_NOT_CREATED                         = "Failed to create tags {0}";
     public static final String TAGS_NOT_FOUND                           = "Failed to find tags";
     public static final String TAGS_NOT_FOUND_1                         = "Failed to find tags {0}";
-
+    public static final String LEVELS_NOT_CREATED                       = "Failed to create levels";
+    public static final String LEVELS_NOT_FOUND                         = "Failed to find levels";
+    public static final String LEVEL_DELETED                            = "Level {0} deleted";
+    public static final String LEVEL_NOT_DELETED                        = "Failed to delete level {0}";
+    public static final String LEVELS_DELETE_ALL_NOT_ALLOWED            = "Deleting all levels not allowed";
     /**
      * This class is not to be instantiated.
      */

--- a/src/main/java/org/phoebus/olog/entity/Level.java
+++ b/src/main/java/org/phoebus/olog/entity/Level.java
@@ -18,10 +18,12 @@
 
 package org.phoebus.olog.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Represents a "Level" value. Sites may choose another name for this entity, e.g. "Entry Type".
  * In the underlying repository only one object is allowed to be the default level.
- * @param name Unique name
+ * @param name Unique, case-sensitive name
  * @param defaultLevel Specifies if this is the default level. Clients can use this to
  *                     avoid active selection.
  */

--- a/src/main/java/org/phoebus/olog/entity/Level.java
+++ b/src/main/java/org/phoebus/olog/entity/Level.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity;
+
+/**
+ * Represents a "Level" value. Sites may choose another name for this entity, e.g. "Entry Type".
+ * In the underlying repository only one object is allowed to be the default level.
+ * @param name Unique name
+ * @param defaultLevel Specifies if this is the default level. Clients can use this to
+ *                     avoid active selection.
+ */
+public record Level(String name, boolean defaultLevel) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -115,6 +115,8 @@ elasticsearch.sequence.index: olog_sequence
 
 elasticsearch.template.index: olog_templates
 
+elasticsearch.level.index: olog_levels
+
 # Archive modified log entries
 elasticsearch.log.archive.index: olog_archived_logs
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -157,9 +157,9 @@ levels=Urgent,Suggestion,Info,Request,Problem
 # NOTE: Non-numeric values will trigger exception and fail startup of service.
 # By default Elasticsearch will return 10 items matching a query.
 # This may bee too limiting, e.g. when client requests all tags.
-elasticsearch.result.size.logbooks=10
-elasticsearch.result.size.tags=10
-elasticsearch.result.size.properties=10
+elasticsearch.result.size.logbooks=100
+elasticsearch.result.size.tags=100
+elasticsearch.result.size.properties=100
 # Default log entry search size if client does not set "limit" request parameter
 elasticsearch.result.size.search.default=100
 # Max log entry search size

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -160,10 +160,12 @@ levels=Urgent,Suggestion,Info,Request,Problem
 elasticsearch.result.size.logbooks=100
 elasticsearch.result.size.tags=100
 elasticsearch.result.size.properties=100
+elasticsearch.result.size.levels=100
 # Default log entry search size if client does not set "limit" request parameter
 elasticsearch.result.size.search.default=100
 # Max log entry search size
 elasticsearch.result.size.search.max=1000
+
 
 # Default markup scheme. This is applied by default, i.e. if not overridden by client
 # or service configuration.

--- a/src/main/resources/default_levels.json
+++ b/src/main/resources/default_levels.json
@@ -1,0 +1,26 @@
+[
+    {
+    "name": "Urgent",
+        "defaultLevel": false
+    },
+    {
+        "name": "Suggestion",
+        "defaultLevel": false
+    },
+    {
+        "name": "Info",
+        "defaultLevel": true
+    },
+    {
+        "name": "Request",
+        "defaultLevel": false
+    },
+    {
+        "name": "Problem",
+        "defaultLevel": false
+    },
+    {
+        "name": "Bad",
+        "defaultLevel": true
+    }
+]

--- a/src/main/resources/level_mapping.json
+++ b/src/main/resources/level_mapping.json
@@ -1,0 +1,12 @@
+{
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "keyword"
+      },
+      "isDefault": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
+++ b/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
@@ -1,0 +1,217 @@
+package org.phoebus.olog;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.DeleteOperation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.phoebus.olog.entity.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = AuthenticationResource.class)
+@ContextConfiguration(classes = ElasticConfig.class)
+@TestPropertySource(locations = "classpath:test_application.properties")
+@SuppressWarnings("unused")
+class LevelsRepositoryIT {
+
+    @Autowired
+    private LevelRepository levelRepository;
+
+    private final Level level1 = new Level("level1", true);
+    private final Level level2 = new Level("level2", false);
+    private final Level level3 = new Level("level3", true);
+
+    // Read the elastic index and type from the application.properties
+    @Value("${elasticsearch.level.index:olog_levels}")
+    private String ES_LEVEL_INDEX;
+
+    @Autowired
+    @Qualifier("client")
+    ElasticsearchClient client;
+
+    /**
+     * Test the creation of a test tag
+     *
+     * @throws IOException
+     */
+    @Test
+    void createLevel() throws IOException {
+        levelRepository.save(level1);
+        Optional<Level> result = levelRepository.findById(level1.name());
+        assertThat("Failed to create Level " + level1.name(), result.isPresent() && result.get().equals(level1));
+
+        cleanUp(List.of(level1));
+    }
+
+    /**
+     * Test the deletion of a test tag
+     *
+     * @throws IOException
+     */
+    @Test
+    void deleteLevel() throws IOException {
+        levelRepository.save(level2);
+        Optional<Level> result = levelRepository.findById(level2.name());
+        assertThat("Failed to create level " + level2.name(), result.isPresent() && result.get().equals(level2));
+
+        levelRepository.delete(level2);
+        result = levelRepository.findById(level2.name());
+        assertThat("Failed to delete level ", result.isEmpty());
+
+        cleanUp(List.of(level1));
+    }
+
+    /**
+     * create a set of tags
+     */
+    @Test
+    void createLevels() {
+        List<Level> levels = Arrays.asList(level1, level2);
+        try {
+            List<Level> result = new ArrayList<>();
+            levelRepository.saveAll(levels).forEach(result::add);
+            assertThat("Failed to create multiple levels", result.containsAll(levels));
+
+            List<Level> findAll = new ArrayList<>();
+            levelRepository.findAll().forEach(findAll::add);
+            assertThat("Failed to create multiple leevls ", findAll.containsAll(levels));
+        } finally {
+            // Manual cleanup
+            cleanUp(levels);
+        }
+    }
+
+    /**
+     * delete a set of tags
+     */
+    @Test
+    void deleteTags() {
+        List<Level> tags = Arrays.asList(level1, level2);
+        try {
+            List<Level> result = new ArrayList<>();
+            levelRepository.saveAll(tags).forEach(result::add);
+
+            levelRepository.deleteAll(tags);
+
+            Iterable<Level> levels = levelRepository.findAll();
+            Iterator<Level> iterator = levels.iterator();
+            while(iterator.hasNext()){
+                Level level = iterator.next();
+                if(level.name().equals(level1.name()) || level.name().equals(level2.name())){
+                    fail("Found level that should be deleted");
+                }
+            }
+        } finally {
+            // Manual cleanup
+            cleanUp(tags);
+        }
+    }
+
+    @Test
+    void findAllLevels() {
+        List<Level> levels = Arrays.asList(level1, level2);
+        try {
+            levelRepository.saveAll(levels);
+            List<Level> findAll = new ArrayList<>();
+            levelRepository.findAll().forEach(findAll::add);
+            assertThat("Failed to list all levels", findAll.containsAll(levels));
+        } finally {
+            // Manual cleanup
+            cleanUp(levels);
+        }
+    }
+
+    @Test
+    void findAllLevelsByIds() throws IOException {
+        List<Level> levels = Arrays.asList(level1, level2);
+        try {
+            levelRepository.saveAll(levels);
+
+            List<Level> findAllById = new ArrayList<>();
+            levelRepository.findAllById(Arrays.asList("level1", "level2"))
+                    .forEach(findAllById::add);
+            assertTrue(
+                    findAllById.size() == 2 && findAllById.contains(level1) && findAllById.contains(level2),
+                    "Failed to search by id level1 and level2 ");
+        } finally {
+            // Manual cleanup
+            cleanUp(levels);
+        }
+    }
+
+    @Test
+    void findLevelById() {
+        List<Level> levels = Arrays.asList(level1, level2);
+        try {
+            levelRepository.saveAll(levels);
+            assertEquals(level1, levelRepository.findById(level1.name()).get(), "Failed to find by index level: " + level1.name());
+            assertEquals(level2, levelRepository.findById(level2.name()).get(), "Failed to find by index level: " + level2.name());
+        } finally {
+            // Manual cleanup
+            cleanUp(levels);
+        }
+    }
+
+    @Test
+    void checkLevelExists() {
+        List<Level> levels = Arrays.asList(level1, level2);
+        try {
+            levelRepository.saveAll(levels);
+
+            assertTrue(levelRepository.existsById(level1.name()),
+                    "Failed to check if exists level: " + level1.name());
+            assertTrue(levelRepository.existsById(level2.name()),
+                    "Failed to check if exists level: " + level2.name());
+
+            assertFalse(levelRepository.existsById("non-existant-tag"),
+                    "Failed to check if exists level: non-existant-tag");
+        } finally {
+            // Manual cleanup
+            cleanUp(levels);
+        }
+    }
+
+    /**
+     * Cleanup the given levels
+     *
+     * @param levels
+     */
+
+    private void cleanUp(List<Level> levels) {
+        List<BulkOperation> bulkOperations = new ArrayList<>();
+        levels.forEach(level -> bulkOperations.add(DeleteOperation.of(i ->
+                i.index(ES_LEVEL_INDEX).id(level.name()))._toBulkOperation()));
+        BulkRequest bulkRequest =
+                BulkRequest.of(r ->
+                        r.operations(bulkOperations).refresh(Refresh.True));
+        try {
+            client.bulk(bulkRequest);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
+++ b/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
@@ -85,6 +85,34 @@ class LevelsRepositoryIT {
         cleanUp(List.of(level1));
     }
 
+    @Test
+    void deleteAll() throws IOException {
+        levelRepository.saveAll(List.of(level1, level2));
+        levelRepository.deleteAll();
+
+        Optional<Level> result =
+                levelRepository.findById(level1.name());
+        assertThat("Failed to delete level1 ", result.isEmpty());
+        result =
+                levelRepository.findById(level2.name());
+        assertThat("Failed to delete level2 ", result.isEmpty());
+
+    }
+
+    @Test
+    void deleteAllById() throws IOException {
+        levelRepository.saveAll(List.of(level1, level2));
+        levelRepository.deleteAllById(List.of("level1", "level2"));
+
+        Optional<Level> result =
+                levelRepository.findById(level1.name());
+        assertThat("Failed to delete level1 ", result.isEmpty());
+        result =
+                levelRepository.findById(level2.name());
+        assertThat("Failed to delete level2 ", result.isEmpty());
+
+    }
+
     /**
      * create a set of tags
      */

--- a/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
+++ b/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
@@ -110,7 +110,6 @@ class LevelsRepositoryIT {
         result =
                 levelRepository.findById(level2.name());
         assertThat("Failed to delete level2 ", result.isEmpty());
-
     }
 
     /**

--- a/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
+++ b/src/test/java/org/phoebus/olog/LevelsRepositoryIT.java
@@ -53,27 +53,17 @@ class LevelsRepositoryIT {
     @Qualifier("client")
     ElasticsearchClient client;
 
-    /**
-     * Test the creation of a test tag
-     *
-     * @throws IOException
-     */
     @Test
-    void createLevel() throws IOException {
-        levelRepository.save(level1);
+    void createLevel() {
+        Level l = levelRepository.save(level1);
         Optional<Level> result = levelRepository.findById(level1.name());
         assertThat("Failed to create Level " + level1.name(), result.isPresent() && result.get().equals(level1));
 
         cleanUp(List.of(level1));
     }
 
-    /**
-     * Test the deletion of a test tag
-     *
-     * @throws IOException
-     */
     @Test
-    void deleteLevel() throws IOException {
+    void deleteLevel()  {
         levelRepository.save(level2);
         Optional<Level> result = levelRepository.findById(level2.name());
         assertThat("Failed to create level " + level2.name(), result.isPresent() && result.get().equals(level2));
@@ -86,7 +76,7 @@ class LevelsRepositoryIT {
     }
 
     @Test
-    void deleteAll() throws IOException {
+    void deleteAll() {
         levelRepository.saveAll(List.of(level1, level2));
         levelRepository.deleteAll();
 
@@ -100,7 +90,7 @@ class LevelsRepositoryIT {
     }
 
     @Test
-    void deleteAllById() throws IOException {
+    void deleteAllById() {
         levelRepository.saveAll(List.of(level1, level2));
         levelRepository.deleteAllById(List.of("level1", "level2"));
 
@@ -173,7 +163,7 @@ class LevelsRepositoryIT {
     }
 
     @Test
-    void findAllLevelsByIds() throws IOException {
+    void findAllLevelsByIds() {
         List<Level> levels = Arrays.asList(level1, level2);
         try {
             levelRepository.saveAll(levels);

--- a/src/test/java/org/phoebus/olog/LevelsResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LevelsResourceTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.phoebus.olog.entity.Level;
+import org.phoebus.olog.entity.Property;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@ContextHierarchy({@ContextConfiguration(classes = {ResourcesTestConfig.class})})
+@WebMvcTest(LevelsResourceTest.class)
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+public class LevelsResourceTest extends ResourcesTestBase {
+
+    @SuppressWarnings("unused")
+    @Autowired
+    private LevelRepository levelRepository;
+
+    private static Level level1;
+    private static Level level2;
+    private static Level level3;
+
+    @BeforeAll
+    public static void init() {
+        level1 = new Level("level1", true);
+        level2 = new Level("level2", false);
+        level3 = new Level("level3", true);
+    }
+
+    @Test
+    void testFindAll() throws Exception {
+        when(levelRepository.findAll()).thenReturn(Arrays.asList(level1, level2));
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LEVEL_RESOURCE_RUI);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Iterable<Level> levels = objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<>() {
+        });
+        assertEquals("level1", levels.iterator().next().name());
+        verify(levelRepository, times(1)).findAll();
+        reset(levelRepository);
+    }
+
+    @Test
+    void testFindById() throws Exception {
+        when(levelRepository.findById("level1")).thenReturn(Optional.of(level1));
+        MockHttpServletRequestBuilder request = get("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1");
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Level level = objectMapper.readValue(result.getResponse().getContentAsString(), Level.class);
+        assertEquals("level1", level.name());
+        verify(levelRepository, times(1)).findById("level1");
+        reset(levelRepository);
+    }
+
+    @Test
+    void testFindByIdDoesNotExist() throws Exception {
+        when(levelRepository.findById("level1")).thenReturn(Optional.empty());
+        MockHttpServletRequestBuilder request = get("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1");
+        mockMvc.perform(request).andExpect(status().isNotFound())
+                .andReturn();
+        verify(levelRepository, times(1)).findById("level1");
+        reset(levelRepository);
+    }
+
+    @Test
+    void testCreateLevelUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testCreateLevel() throws Exception {
+
+        when(levelRepository.save(argThat(new LevelMatcher(level1)))).thenReturn(level1);
+
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(level1));
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        objectMapper.readValue(result.getResponse().getContentAsString(), Level.class);
+        verify(levelRepository, times(1)).save(level1);
+        reset(levelRepository);
+    }
+
+    @Test
+    void testUpdateLevelUnauthoroized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI)
+                .session(new MockHttpSession());
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testSaveAll() throws Exception {
+
+        when(levelRepository.saveAll(Collections.singletonList(argThat(new LevelMatcher(level1)))))
+                .thenReturn(List.of(level1));
+
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(Collections.singletonList(level1)));
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<Iterable<Level>>() {
+        });
+        verify(levelRepository, times(1)).saveAll(List.of(level1));
+        reset(levelRepository);
+    }
+
+    @Test
+    void testDeleteUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testDeleteNot() throws Exception {
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION);
+        mockMvc.perform(request).andExpect(status().isNotFound());
+        reset(levelRepository);
+    }
+
+    @Test
+    void testDeleteNotFound() throws Exception {
+        when(levelRepository.findById("level1")).thenReturn(Optional.of(level1));
+
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION);
+        mockMvc.perform(request).andExpect(status().isOk());
+        verify(levelRepository, times(1)).findById("level1");
+        verify(levelRepository, times(1)).deleteById("level1");
+
+        reset(levelRepository);
+    }
+
+    @Test
+    void testCrateFailOnDuplicateDefaults() throws Exception{
+        when(levelRepository.findAll()).thenReturn(List.of(level1, level2));
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/level3")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(level3));
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+        verify(levelRepository, times(1)).findAll();
+        reset(levelRepository);
+    }
+
+    @Test
+    void testCrateFailOnNullName() throws Exception{
+        Level level = new Level(null, false);
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/someLevel")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(level));
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testCrateFailOnEmptyName() throws Exception{
+        Level level = new Level("", false);
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LEVEL_RESOURCE_RUI +
+                "/someLevel")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(level));
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+    }
+
+    /**
+     * A matcher used to work around issues with {@link Property#equals(Object)} when using the mocks.
+     */
+    private static class LevelMatcher implements ArgumentMatcher<Level> {
+        private final Level expected;
+
+        public LevelMatcher(Level expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public boolean matches(Level obj) {
+            if (!(obj instanceof Level)) {
+                return false;
+            }
+            Level actual = obj;
+
+            return actual.name().equals(expected.name());
+        }
+    }
+}

--- a/src/test/java/org/phoebus/olog/ResourcesTestConfig.java
+++ b/src/test/java/org/phoebus/olog/ResourcesTestConfig.java
@@ -119,4 +119,8 @@ public class ResourcesTestConfig {
         return Mockito.mock(LogTemplateRepository.class);
     }
 
+    @Bean
+    public LevelRepository levelRepository(){
+        return Mockito.mock(LevelRepository.class);
+    }
 }

--- a/src/test/resources/no_ldap_test_application.properties
+++ b/src/test/resources/no_ldap_test_application.properties
@@ -22,6 +22,4 @@ demo_auth.enabled = true
 
 spring.session.timeout=30
 
-levels=A,B,C,D,E
-
 elasticsearch.create.indices: false

--- a/src/test/resources/no_ldap_test_application.properties
+++ b/src/test/resources/no_ldap_test_application.properties
@@ -23,3 +23,5 @@ demo_auth.enabled = true
 spring.session.timeout=30
 
 levels=A,B,C,D,E
+
+elasticsearch.create.indices: false

--- a/src/test/resources/no_ldap_test_application_infinite_session_duration.properties
+++ b/src/test/resources/no_ldap_test_application_infinite_session_duration.properties
@@ -21,3 +21,5 @@ embedded_ldap.enabled = false
 demo_auth.enabled = true
 
 spring.session.timeout=-1
+
+elasticsearch.create.indices: false

--- a/src/test/resources/test_application.properties
+++ b/src/test/resources/test_application.properties
@@ -52,6 +52,8 @@ elasticsearch.sequence.index: test_olog_sequence
 
 elasticsearch.template.index: test_olog_templates
 
+elasticsearch.levels.index: test_olog_levels
+
 ############################## Mongo gridfs client ###############################
 mongo.database:ologAttachments
 mongo.host:localhost


### PR DESCRIPTION
List of Levels (or Entry Types, as renamed at ESS) is set as a client property. This has implications on deployment scenarios where instances may need to define different list of levels.

This PR adds support for a new Elasticsearch index where list of ```Level```s are maintained. The ```Level``` data object also has a ```defaultLevel``` property such that clients may set the level without having to prompt user. Only one single```Level``` may be marked as default.

REST endpoints are provided to retrieve and manage ```Level``` objects.