### PR TITLE
Fix levels and properties import

### DIFF
--- a/src/main/java/org/phoebus/olog/ElasticConfig.java
+++ b/src/main/java/org/phoebus/olog/ElasticConfig.java
@@ -152,6 +152,9 @@ public class ElasticConfig {
     @Value("${default.properties.url}")
     @SuppressWarnings("unused")
     private String defaultPropertiesURL;
+    @Value("${default.levels.url}")
+    @SuppressWarnings("unused")
+    private String defaultLevelsURL;
 
     private ElasticsearchClient client;
     private static final AtomicBoolean esInitialized = new AtomicBoolean();
@@ -419,12 +422,12 @@ public class ElasticConfig {
         }
 
         // Setup the default levels
-        String propertiesURL = defaultPropertiesURL;
-        if (propertiesURL.isEmpty()) {
+        String levelsURL = defaultLevelsURL;
+        if (levelsURL.isEmpty()) {
             final URL resource = getClass().getResource("/default_levels.json");
-            propertiesURL = resource.toExternalForm();
+            levelsURL = resource.toExternalForm();
         }
-        try (InputStream input = new URL(propertiesURL).openStream()) {
+        try (InputStream input = new URL(levelsURL).openStream()) {
             List<org.phoebus.olog.entity.Level> jsonTag = mapper.readValue(input, new TypeReference<>() {
             });
 
@@ -459,13 +462,13 @@ public class ElasticConfig {
                             defaultLevelExists.set(true);
                         }
                     } catch (IOException e) {
-                        logger.log(Level.WARNING, MessageFormat.format(TextUtil.ELASTIC_FAILED_TO_INITIALIZE_PROPERTY,
+                        logger.log(Level.WARNING, MessageFormat.format(TextUtil.ELASTIC_FAILED_TO_INITIALIZE_LEVEL,
                                 level.name()), e);
                     }
                 }
             });
         } catch (IOException ex) {
-            logger.log(Level.WARNING, TextUtil.ELASTIC_FAILED_TO_INITIALIZE_PROPERTIES, ex);
+            logger.log(Level.WARNING, TextUtil.ELASTIC_FAILED_TO_INITIALIZE_LEVELS, ex);
         }
     }
 }

--- a/src/main/java/org/phoebus/olog/TextUtil.java
+++ b/src/main/java/org/phoebus/olog/TextUtil.java
@@ -52,6 +52,8 @@ public class TextUtil {
     public static final String ELASTIC_FAILED_TO_INITIALIZE_PROPERTIES  = "Failed to initialize properties";
     public static final String ELASTIC_FAILED_TO_INITIALIZE_TAG         = "Failed to initialize tag {0}";
     public static final String ELASTIC_FAILED_TO_INITIALIZE_TAGS        = "Failed to initialize tags";
+    public static final String ELASTIC_FAILED_TO_INITIALIZE_LEVEL       = "Failed to initialize level {0}";
+    public static final String ELASTIC_FAILED_TO_INITIALIZE_LEVELS      = "Failed to initialize levels";
 
     // ----------------------------------------------------------------------------------------------------
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -188,6 +188,7 @@ spring.mvc.static-path-pattern=/Olog/**
 default.logbook.url=
 default.tags.url=
 default.properties.url=
+default.levels.url=
 
 ########### OpenAPI / Swagger #############
 #OPENAPI


### PR DESCRIPTION
This PR will:
- Fix the import of default levels using the `default.levels.url` option in `application.properties`
- Restore the import of properties from `default.properties.url` from tag 5.0.2 