### PR TITLE
Web sockets for client notifications 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,14 @@
             <artifactId>spring-security-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-websocket</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
         </dependency>
@@ -591,7 +599,7 @@
                         <configuration>
                             <publishingServerId>phoebus-releases</publishingServerId>
                             <checksums>required</checksums>
-                            <centralBaseUsrl>https://central.sonatype.com</centralBaseUsrl>
+                            <centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/main/java/org/phoebus/olog/InfoResource.java
+++ b/src/main/java/org/phoebus/olog/InfoResource.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import static org.phoebus.olog.OlogResourceDescriptors.OLOG_SERVICE_INFO;
-//import com.mongodb.client.MongoClient;
 
 @RestController
 @RequestMapping(OLOG_SERVICE_INFO)

--- a/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
+++ b/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
@@ -32,12 +32,12 @@ public class OlogResourceDescriptors
     /**
      * Topic for the messages pushed from the service to subscriber clients, which need to specify it in the same manner.
      */
-    public static final String WEB_SOCKET_MESSAGES_TOPIC = "/" + OLOG_SERVICE + WEB_SOCKET_BASE + "/messages";
+    public static final String WEB_SOCKET_MESSAGES_TOPIC = WEB_SOCKET_BASE + "/messages";
 
     /**
      * Prefix of endpoints for client messages, i.e. /Olog/web-socket. An endpoint named/annotated &quot;echo&quot; will then
      * be specified by client as /Olog/web-socket/echo.
      */
-    public static final String WEB_SOCKET_APPLICATION_PREFIX = "/" + OLOG_SERVICE + WEB_SOCKET_BASE;
+    public static final String WEB_SOCKET_APPLICATION_PREFIX = WEB_SOCKET_BASE;
 
 }

--- a/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
+++ b/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
@@ -27,7 +27,7 @@ public class OlogResourceDescriptors
      *     </ul>
      * </p>
      */
-    public static final String WEB_SOCKET_BASE = "/web-socket";
+    public static final String WEB_SOCKET_BASE = "/" + OLOG_SERVICE + "/web-socket";
 
     /**
      * Topic for the messages pushed from the service to subscriber clients, which need to specify it in the same manner.

--- a/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
+++ b/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class OlogResourceDescriptors
 {
-    static final String OLOG_SERVICE = "Olog";
+    public static final String OLOG_SERVICE = "Olog";
     static final String OLOG_SERVICE_INFO = OLOG_SERVICE;
     static final String TAG_RESOURCE_URI = OLOG_SERVICE + "/tags";
     static final String LOGBOOK_RESOURCE_URI = OLOG_SERVICE + "/logbooks";
@@ -16,4 +16,7 @@ public class OlogResourceDescriptors
     static final String HELP_URI = OLOG_SERVICE + "/help";
     public static final String LOG_TEMPLATE_RESOURCE_URI = OLOG_SERVICE + "/templates";
     public static final String LEVEL_RESOURCE_RUI = OLOG_SERVICE + "/levels";
+
+    public static final String WEB_SOCKET_CONNECT_ENDPOINT = "/" + OLOG_SERVICE + "/web-socket";
+    public static final String WEB_SOCKET_MESSAGES_TOPIC = "/" + OLOG_SERVICE + "/messages";
 }

--- a/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
+++ b/src/main/java/org/phoebus/olog/OlogResourceDescriptors.java
@@ -17,6 +17,27 @@ public class OlogResourceDescriptors
     public static final String LOG_TEMPLATE_RESOURCE_URI = OLOG_SERVICE + "/templates";
     public static final String LEVEL_RESOURCE_RUI = OLOG_SERVICE + "/levels";
 
-    public static final String WEB_SOCKET_CONNECT_ENDPOINT = "/" + OLOG_SERVICE + "/web-socket";
-    public static final String WEB_SOCKET_MESSAGES_TOPIC = "/" + OLOG_SERVICE + "/messages";
+    /**
+     * The base path element for web socket related communication.
+     * <p>
+     *     <b>NOTE:</b>
+     *     <ul>
+     *         <li>Clients will need to connect to ws(s)://&lt;host&gt;:&lt;port&gt;/Olog/web-socket</li>
+     *         <li>Clients will need to subscribe to /Olog/web-socket/&lt;topic name&gt;, e.g. /Olog/web-socket/messages</li>
+     *     </ul>
+     * </p>
+     */
+    public static final String WEB_SOCKET_BASE = "/web-socket";
+
+    /**
+     * Topic for the messages pushed from the service to subscriber clients, which need to specify it in the same manner.
+     */
+    public static final String WEB_SOCKET_MESSAGES_TOPIC = "/" + OLOG_SERVICE + WEB_SOCKET_BASE + "/messages";
+
+    /**
+     * Prefix of endpoints for client messages, i.e. /Olog/web-socket. An endpoint named/annotated &quot;echo&quot; will then
+     * be specified by client as /Olog/web-socket/echo.
+     */
+    public static final String WEB_SOCKET_APPLICATION_PREFIX = "/" + OLOG_SERVICE + WEB_SOCKET_BASE;
+
 }

--- a/src/main/java/org/phoebus/olog/entity/websocket/MessageType.java
+++ b/src/main/java/org/phoebus/olog/entity/websocket/MessageType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity.websocket;
+
+public enum MessageType {
+    NEW_LOG_ENTRY,
+    LOG_ENTRY_UPDATED,
+    SHOW_BANNER
+}

--- a/src/main/java/org/phoebus/olog/entity/websocket/WebSocketMessage.java
+++ b/src/main/java/org/phoebus/olog/entity/websocket/WebSocketMessage.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.entity.websocket;
+
+public record WebSocketMessage(MessageType messageType, String payload) {
+}

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
@@ -33,6 +33,14 @@ import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_MESSAGES_TOPIC
 
 /**
  * Sets up bare minimum web socket for STOMP clients.
+ * <p>
+ *     <b>NOTE:</b> Client side URL/paths are:
+ *     <ul>
+ *         <li>Connection established on ws(s)://host:port/Olog/web-socket</li>
+ *         <li>Subscription to messages (i.e. topic name) on: /Olog/web-socket/messages</li>
+ *         <li>Echo endpoint (for testing purposes): /Olog/web-socket/echo. Message is echoed to topic /Olog/web-socket/messages.</li>
+ *     </ul>
+ * </p>
  */
 @Configuration
 @EnableWebSocketMessageBroker

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
@@ -27,7 +27,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_CONNECT_ENDPOINT;
+import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_APPLICATION_PREFIX;
+import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_BASE;
 import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_MESSAGES_TOPIC;
 
 /**
@@ -50,11 +51,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.enableSimpleBroker(WEB_SOCKET_MESSAGES_TOPIC)
                 .setHeartbeatValue(new long[]{30000, 30000})
                 .setTaskScheduler(this.messageBrokerTaskScheduler);
-        config.setApplicationDestinationPrefixes(WEB_SOCKET_CONNECT_ENDPOINT);
+        config.setApplicationDestinationPrefixes(WEB_SOCKET_APPLICATION_PREFIX);
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint(WEB_SOCKET_CONNECT_ENDPOINT);
+        registry.addEndpoint(WEB_SOCKET_BASE);
     }
 }

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@SuppressWarnings("unused")
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/messages");
+        config.setApplicationDestinationPrefixes("/websocket");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/websocket");
+    }
+}

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketConfig.java
@@ -18,25 +18,43 @@
 
 package org.phoebus.olog.websocket;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_CONNECT_ENDPOINT;
+import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_MESSAGES_TOPIC;
+
+/**
+ * Sets up bare minimum web socket for STOMP clients.
+ */
 @Configuration
 @EnableWebSocketMessageBroker
 @SuppressWarnings("unused")
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private TaskScheduler messageBrokerTaskScheduler;
+
+    @Autowired
+    public void setMessageBrokerTaskScheduler(@Lazy TaskScheduler taskScheduler) {
+        this.messageBrokerTaskScheduler = taskScheduler;
+    }
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/messages");
-        config.setApplicationDestinationPrefixes("/websocket");
+        config.enableSimpleBroker(WEB_SOCKET_MESSAGES_TOPIC)
+                .setHeartbeatValue(new long[]{30000, 30000})
+                .setTaskScheduler(this.messageBrokerTaskScheduler);
+        config.setApplicationDestinationPrefixes(WEB_SOCKET_CONNECT_ENDPOINT);
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/websocket");
+        registry.addEndpoint(WEB_SOCKET_CONNECT_ENDPOINT);
     }
 }

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketController.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketController.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.websocket;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@SuppressWarnings("unused")
+public class WebSocketController {
+
+    @MessageMapping("/echo")
+    @SendTo("/messages")
+    public String echo(String message) {
+        return message;
+    }
+}

--- a/src/main/java/org/phoebus/olog/websocket/WebSocketService.java
+++ b/src/main/java/org/phoebus/olog/websocket/WebSocketService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.olog.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.phoebus.olog.entity.websocket.WebSocketMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
+import org.springframework.stereotype.Service;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_MESSAGES_TOPIC;
+
+/**
+ * Utility service used to dispatch messages to web socket clients subscribing to the
+ * {@link org.phoebus.olog.OlogResourceDescriptors#WEB_SOCKET_MESSAGES_TOPIC} topic.
+ */
+@Service
+public class WebSocketService {
+
+    @SuppressWarnings("unused")
+    @Autowired
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @SuppressWarnings("unused")
+    @Autowired
+    private SimpUserRegistry simpUserRegistry;
+
+    @SuppressWarnings("unused")
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final Logger logger = Logger.getLogger(WebSocketService.class.getName());
+
+    /**
+     * @param webSocketMessage Non-null {@link WebSocketMessage}, will be converted to a JSON string before it is dispatched.
+     */
+    public void sendMessageToClients(@NonNull WebSocketMessage webSocketMessage) {
+        try {
+            String message = objectMapper.writeValueAsString(webSocketMessage);
+            simpMessagingTemplate.convertAndSend(WEB_SOCKET_MESSAGES_TOPIC, message);
+        } catch (JsonProcessingException e) {
+            logger.log(Level.WARNING, "Failed to write web socket message to json string", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,11 +17,13 @@ server.error.include-message=always
 # suppress the logging from spring boot 
 # during debugging this should be set to DEBUG
 logging.level.root=INFO
-logging.level.org.springframework=INFO
+logging.level.org.springframework=DEBUG
 logging.level.org.apache.catalina=INFO
 logging.level.org.apache.kafka=INFO
-logging.level.org.springframework.web=INFO
+logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.security=INFO
+logging.level.org.springframework.messaging=DEBUG
+logging.level.org.springframework.web.socket=DEBUG
 
 spring.main.allow-bean-definition-overriding=true
 

--- a/src/test/java/org/phoebus/olog/LogResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTest.java
@@ -19,6 +19,7 @@
 package org.phoebus.olog;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -144,6 +145,11 @@ public class LogResourceTest extends ResourcesTestBase {
                 .build();
     }
 
+    @AfterEach
+    public void resetMocks(){
+        reset(logRepository, logbookRepository, tagRepository, webSocketService);
+    }
+
     @Test
     void testGetLogById() throws Exception {
         when(logRepository.findById("1")).thenAnswer(invocationOnMock -> Optional.of(log1));
@@ -154,7 +160,6 @@ public class LogResourceTest extends ResourcesTestBase {
         Log log = objectMapper.readValue(result.getResponse().getContentAsString(), Log.class);
         assertEquals("description1", log.getDescription());
         verify(logRepository, times(1)).findById("1");
-        reset(logRepository);
     }
 
     @Test
@@ -164,7 +169,6 @@ public class LogResourceTest extends ResourcesTestBase {
         MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/1");
         mockMvc.perform(request).andExpect(status().isNotFound());
         verify(logRepository, times(1)).findById("1");
-        reset(logRepository);
     }
 
     @Test
@@ -186,7 +190,6 @@ public class LogResourceTest extends ResourcesTestBase {
         assertEquals(Long.valueOf(1L), logs.iterator().next().getId());
 
         verify(logRepository, times(1)).search(map);
-        reset(logRepository);
     }
 
     @Test
@@ -262,7 +265,6 @@ public class LogResourceTest extends ResourcesTestBase {
         assertEquals(Long.valueOf(1L), savedLog.getId());
 
         verify(webSocketService, times(1)).sendMessageToClients(new WebSocketMessage(MessageType.NEW_LOG_ENTRY, null));
-        reset(logbookRepository, tagRepository, logRepository, webSocketService);
     }
 
     /**
@@ -300,7 +302,6 @@ public class LogResourceTest extends ResourcesTestBase {
         assertEquals(Long.valueOf(1L), savedLog.getId());
 
         verify(webSocketService, times(1)).sendMessageToClients(new WebSocketMessage(MessageType.LOG_ENTRY_UPDATED, "1"));
-        reset(logRepository, webSocketService);
     }
 
     @Test
@@ -329,8 +330,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
-
-        reset(logRepository);
     }
 
     /**
@@ -372,7 +371,6 @@ public class LogResourceTest extends ResourcesTestBase {
                         .file(fileMetadataDescription)
                         .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
                 .andExpect(status().is(200));
-        reset(logRepository);
     }
 
     @Test
@@ -416,7 +414,6 @@ public class LogResourceTest extends ResourcesTestBase {
         Log savedLog = objectMapper.readValue(result.getResponse().getContentAsString(), Log.class);
         assertEquals(Long.valueOf(1L), savedLog.getId());
         verify(webSocketService, times(1)).sendMessageToClients(new WebSocketMessage(MessageType.NEW_LOG_ENTRY, null));
-        reset(logbookRepository, tagRepository, logRepository, webSocketService);
     }
 
     @Test
@@ -451,8 +448,6 @@ public class LogResourceTest extends ResourcesTestBase {
         Log savedLog = objectMapper.readValue(result.getResponse().getContentAsString(), Log.class);
         assertEquals(Long.valueOf(1L), savedLog.getId());
         verify(webSocketService, times(1)).sendMessageToClients(Mockito.any(WebSocketMessage.class));
-        reset(logbookRepository, tagRepository, logRepository, webSocketService);
-
     }
 
     @Test
@@ -497,8 +492,6 @@ public class LogResourceTest extends ResourcesTestBase {
                         .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
         verify(webSocketService, Mockito.never()).sendMessageToClients(Mockito.any(WebSocketMessage.class));
-
-        reset(logbookRepository, tagRepository, logRepository, webSocketService);
     }
 
     @Test
@@ -539,7 +532,6 @@ public class LogResourceTest extends ResourcesTestBase {
                         .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
 
-        reset(logRepository);
     }
 
     @Test
@@ -580,7 +572,6 @@ public class LogResourceTest extends ResourcesTestBase {
                         .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isOk());
 
-        reset(logRepository);
     }
 
     /**
@@ -618,7 +609,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
-        reset(logRepository);
     }
 
     @Test
@@ -635,7 +625,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isOk());
         verify(webSocketService, times(1)).sendMessageToClients(new WebSocketMessage(MessageType.NEW_LOG_ENTRY, null));
-        reset(logRepository, webSocketService);
     }
 
     @Test
@@ -651,7 +640,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
         verify(webSocketService, Mockito.never()).sendMessageToClients(Mockito.any(WebSocketMessage.class));
-        reset(logRepository, webSocketService);
     }
 
     @Test
@@ -671,7 +659,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isBadRequest());
         verify(webSocketService, Mockito.never()).sendMessageToClients(Mockito.any(WebSocketMessage.class));
-        reset(logRepository, webSocketService);
     }
 
     @Test
@@ -689,8 +676,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isOk());
-
-        reset(logRepository);
     }
 
     @Test
@@ -708,8 +693,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isOk());
-
-        reset(logRepository);
     }
 
     @Test
@@ -726,8 +709,6 @@ public class LogResourceTest extends ResourcesTestBase {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
                 .contentType(JSON);
         mockMvc.perform(request).andExpect(status().isOk());
-
-        reset(logRepository);
     }
 
     @Test
@@ -752,7 +733,5 @@ public class LogResourceTest extends ResourcesTestBase {
         } catch (Exception ex) {
             fail("Failed to make request", ex);
         }
-        reset(logRepository);
-
     }
 }

--- a/src/test/java/org/phoebus/olog/LogResourceTestConfig.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTestConfig.java
@@ -16,30 +16,22 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-package org.phoebus.olog.websocket;
+package org.phoebus.olog;
 
-
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.stereotype.Controller;
-
-import static org.phoebus.olog.OlogResourceDescriptors.WEB_SOCKET_MESSAGES_TOPIC;
+import org.mockito.Mockito;
+import org.phoebus.olog.websocket.WebSocketService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 
 /**
- * This {@link Controller} defines an echo endpoint, i.e. for testing or health check purposes...
+ * Sets up suitable mocks for {@link LogResourceTest}
  */
-@Controller
 @SuppressWarnings("unused")
-public class WebSocketController {
+@TestConfiguration
+public class LogResourceTestConfig {
 
-    /**
-     *
-     * @param message Will be echoed back to subscribers to the {@link org.phoebus.olog.OlogResourceDescriptors#WEB_SOCKET_MESSAGES_TOPIC} topic
-     * @return The message received in the call.
-     */
-    @MessageMapping("/echo")
-    @SendTo(WEB_SOCKET_MESSAGES_TOPIC)
-    public String echo(String message) {
-        return message;
+    @Bean
+    public WebSocketService webSocketService(){
+        return Mockito.mock(WebSocketService.class);
     }
 }


### PR DESCRIPTION
This adds web socket support, STOMP style. Intention is to notify clients in the following cases:

1. New log entry created -> clients will need to refresh search view
2. A log entry has been updated -> clients may wish to notify user if that log entry is "in focus"
3. Show banner: this is for future use, e.g. web client banner to show that service is being restarted, upcoming client update, upcoming maintenance work and potential disruptions etc.

The service setup is to employ a 30 s heartbeat. Clients must also connect with a non-zero heartbeat strategy.