### PR TITLE
fix version of spring-boot-maven-plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,7 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
+                        <version>4.0.0-M2</version>
                         <configuration>
                             <executable>true</executable>
                         </configuration>


### PR DESCRIPTION
This Pull Request fixes `spring-boot-maven-plugin` to a specific version. Else, maven will always pick the latest version of the plugin, which makes the project dependencies not reproducible.

This can be problematic, because when building older versions of phoebus-olog, maven will use a different version of `spring-boot-maven-plugin` than the one that was available when the version was released.

I've chosen the latest version, because that's the one that is currently in use, but since it seems like a beta release, it might make sense to choose a different one.