### PR TITLE
Allow wildcrads for cors allowed origins

### DIFF
--- a/src/main/java/org/phoebus/olog/Application.java
+++ b/src/main/java/org/phoebus/olog/Application.java
@@ -25,15 +25,9 @@ import java.util.logging.Logger;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {"org.phoebus.olog"})
+@SuppressWarnings("unused")
 public class Application {
     static final Logger logger = Logger.getLogger("Olog");
-
-    /**
-     * Specifies the allowed origins for CORS requests. Defaults to http://localhost:3000,
-     * which is useful during development of the web front-end in NodeJS.
-     */
-    @Value("#{'${cors.allowed.origins:http://localhost:3000}'.split(',')}")
-    private String[] corsAllowedOrigins;
 
     @Value("${defaultMarkup:commonmark}")
     private String defaultMarkup;
@@ -113,17 +107,17 @@ public class Application {
     }
 
     @Bean
-    public Long propertyProvidersTimeout(){
+    public Long propertyProvidersTimeout() {
         return propertyProvidersTimeout;
     }
 
     @Bean
-    public AcceptHeaderResolver acceptHeaderResolver(){
+    public AcceptHeaderResolver acceptHeaderResolver() {
         return new AcceptHeaderResolver();
     }
 
     @Bean
-    public LogEntryValidator logEntryValidator(){
+    public LogEntryValidator logEntryValidator() {
         return new LogEntryValidator();
     }
 }

--- a/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
+++ b/src/main/java/org/phoebus/olog/FileUploadSizeExceededHandler.java
@@ -44,15 +44,15 @@ public class FileUploadSizeExceededHandler {
      * Specifies the allowed origins for CORS requests. Defaults to http://localhost:3000,
      * which is useful during development of the web front-end in NodeJS.
      */
-    @Value("${cors.allowed.origins:http://localhost:3000}")
-    private String corsAllowedOrigins;
+    @Value("#{'${cors.allowed.origins:http://localhost:3000}'.split(',')}")
+    private String[] corsAllowedOrigins;
 
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<String> handleMaxSizeExceededException(RuntimeException ex, WebRequest request) {
         // These HTTP headers are needed by browsers in order to handle the 413 response properly.
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Access-Control-Allow-Origin", corsAllowedOrigins);
+        headers.add("Access-Control-Allow-Origin", String.join(",", corsAllowedOrigins));
         headers.add("Access-Control-Allow-Credentials", "true");
         return new ResponseEntity<>("Log entry exceeds size limits",
                 headers,

--- a/src/main/java/org/phoebus/olog/WebConfig.java
+++ b/src/main/java/org/phoebus/olog/WebConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 @Configuration
 @PropertySource("classpath:application.properties")
+@SuppressWarnings("unused")
 public class WebConfig implements WebMvcConfigurer {
 
     /**
@@ -44,7 +45,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowCredentials(true)
                 .allowedMethods("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH")
-                .allowedOrigins(corsAllowedOrigins);
+                .allowedOriginPatterns(corsAllowedOrigins);
     }
 
     @Override


### PR DESCRIPTION
Addresses #218.

Allowing wild card patterns in cors allowed origins is not possible without the change in this PR. Still, service will need to be launched with ```-Dcors.allowed.origins=*``` to achieve the effect wanted by #218. In other words, would prefer to leave to the deployment to enable wildcard matching rather than changing the current default.

Will update the README (and the README in https://github.com/Olog/phoebus-olog-web-client) to clarify how to deploy without a reverse proxy to the web client.