### PR TITLE
Removed add attachment endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM maven:3.9.11-eclipse-temurin-25 AS maven-build
 RUN mkdir phoebus-olog
 WORKDIR /phoebus-olog
 COPY . .
+
 RUN mvn clean install \
     -DskipTests=true \
     -Dmaven.javadoc.skip=true \

--- a/src/main/java/org/phoebus/olog/LogResource.java
+++ b/src/main/java/org/phoebus/olog/LogResource.java
@@ -355,37 +355,6 @@ public class LogResource {
 
 
     /**
-     * Add an attachment to log entry identified by logId
-     *
-     * @param logId                   log entry ID
-     * @param file                    the file to be attached
-     * @param filename                name of file
-     * @param id                      UUID for file in mongo
-     * @param fileMetadataDescription file metadata
-     * @return The updated {@link Log}.
-     */
-    @PostMapping("/attachments/{logId}")
-    public Log uploadAttachment(@PathVariable(name = "logId") String logId,
-                                @RequestPart("file") MultipartFile file,
-                                @RequestPart("filename") String filename,
-                                @RequestPart(name = "id", required = false) String id,
-                                @RequestPart(name = "fileMetadataDescription", required = false) String fileMetadataDescription) {
-
-        List<MultipartFile> multipartFiles;
-
-        try {
-            multipartFiles = checkSupportedAttachmentTypes(new MultipartFile[]{file});
-        } catch (IllegalArgumentException exception) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, TextUtil.ATTACHMENT_HEIC_NOT_SUPPORTED);
-        }
-        return saveAttachment(logId,
-                multipartFiles.getFirst(),
-                filename,
-                id,
-                fileMetadataDescription);
-    }
-
-    /**
      * Saves the content of the {@link MultipartFile} to the database.
      *
      * @param logId                   The log id associated with the attachment

--- a/src/test/java/org/phoebus/olog/LogResourceTest.java
+++ b/src/test/java/org/phoebus/olog/LogResourceTest.java
@@ -108,9 +108,6 @@ public class LogResourceTest extends ResourcesTestBase {
     private AttachmentRepository attachmentRepository;
 
     @Autowired
-    private LogEntryValidator logEntryValidator;
-
-    @Autowired
     private WebSocketService webSocketService;
 
     @Autowired
@@ -166,17 +163,17 @@ public class LogResourceTest extends ResourcesTestBase {
             }
 
             @Override
-            public byte[] getBytes() throws IOException {
+            public byte[] getBytes() {
                 return new byte[0];
             }
 
             @Override
-            public InputStream getInputStream() throws IOException {
+            public InputStream getInputStream() {
                 return getClass().getResourceAsStream("/Tulips.jpg");
             }
 
             @Override
-            public void transferTo(File dest) throws IOException, IllegalStateException {
+            public void transferTo(File dest) throws IllegalStateException {
 
             }
         };
@@ -408,39 +405,6 @@ public class LogResourceTest extends ResourcesTestBase {
     }
 
     @Test
-    void testCreateAttachmentUnauthroized() throws Exception {
-        MockHttpServletRequestBuilder request = put("/" + OlogResourceDescriptors.LOG_RESOURCE_URI
-                + "/attachments/1");
-        mockMvc.perform(request).andExpect(status().isUnauthorized());
-    }
-
-    /**
-     * Test only endpoint URI
-     *
-     * @throws Exception
-     */
-    @Test
-    void testCreateAttachment() throws Exception {
-        when(logRepository.findById("1")).thenReturn(Optional.of(log1));
-
-        MockMultipartFile file =
-                new MockMultipartFile("file", "filename.txt", "text/plain", "some xml".getBytes());
-        MockMultipartFile filename =
-                new MockMultipartFile("filename", "filename.txt", "text/plain", "some xml".getBytes());
-        MockMultipartFile fileMetadataDescription =
-                new MockMultipartFile("fileMetadataDescription", "filename.txt", "text/plain", "some xml".getBytes());
-
-        when(attachmentRepository.save(argThat(attachment -> true)))
-                .thenReturn(new Attachment(null, file, "filename.txt", "fileMetadataDescription"));
-        mockMvc.perform(MockMvcRequestBuilders.multipart("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/attachments/1")
-                        .file(file)
-                        .file(filename)
-                        .file(fileMetadataDescription)
-                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
-                .andExpect(status().is(200));
-    }
-
-    @Test
     void testCreateLogMultipart() throws Exception {
         Attachment attachment = new Attachment();
         attachment.setId("attachmentId");
@@ -617,12 +581,9 @@ public class LogResourceTest extends ResourcesTestBase {
             if (!(obj instanceof Log)) {
                 return false;
             }
-            Log actual = (Log) obj;
 
-            boolean match = actual.getId() == expected.getId()
-                    && actual.getDescription().equals(expected.getDescription());
-
-            return match;
+            return obj.getId().equals(expected.getId())
+                    && obj.getDescription().equals(expected.getDescription());
         }
     }
 
@@ -802,7 +763,7 @@ public class LogResourceTest extends ResourcesTestBase {
             }
 
             @Override
-            public void transferTo(File dest) throws IOException, IllegalStateException {
+            public void transferTo(File dest) throws IllegalStateException {
 
             }
         };
@@ -813,40 +774,9 @@ public class LogResourceTest extends ResourcesTestBase {
     }
 
     @Test
-    public void testAnalyzeNotHeic() throws IOException {
+    public void testAnalyzeNotHeic() {
         List<MultipartFile> multipartFiles = logResource.checkSupportedAttachmentTypes(new MultipartFile[]{multipartFile});
-        assertEquals(multipartFiles.size(), 1);
+        assertEquals(1, multipartFiles.size());
 
     }
-
-    void testRssFeedCustomRequestParams() {
-        Log log1Rss = Log.LogBuilder.createLog().id(1L).description("log1description").title("log1title").build();
-        Log log2Rss = Log.LogBuilder.createLog().id(2L).description("log2description").title("log2title").build();
-        when(logRepository.search(any())).thenReturn(new SearchResult(2, List.of(log1Rss, log2Rss)));
-
-        MultiValueMap<String, String> allRequestParams = new LinkedMultiValueMap<>();
-        allRequestParams.put("start", List.of("2025-12-01 10:00:00.000"));
-        allRequestParams.put("end", List.of("2025-12-10 10:00:00.000"));
-        allRequestParams.put("from", List.of("100"));
-        allRequestParams.put("size", List.of("777"));
-
-        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/rss")
-                .params(allRequestParams)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION);
-        try {
-            mockMvc.perform(request)
-                    .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_RSS_XML_VALUE + ";charset=UTF-8"))
-                    .andExpect(content().string(allOf(
-                            containsString("<channel>"),
-                            containsString(log1Rss.getDescription()),
-                            containsString(log2Rss.getDescription()),
-                            containsString(log1Rss.getTitle()),
-                            containsString(log2Rss.getTitle())
-                    )));
-        } catch (Exception ex) {
-            fail("Failed to make request", ex);
-        }
-    }
-
 }


### PR DESCRIPTION
The endpoint to add an attachment to an existing log entry circumvents the intended restriction to not allow additional attachments when updating a log entry. So this PR removes that endpoint.

That said, an upcoming change is to actually support additional attachments when updating a log entry, but that requires more substantial changes to the class ```LogResource```. Such changes would be easier to make if this endpoint would be eliminated.

Also: some cleanup in unit test class.