### PR TITLE
Changed phase for open API doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
               <executions>
                 <execution>
                   <id>documentation</id>
-                  <phase>install</phase>
+                  <phase>package</phase>
                   <goals>
                     <goal>documentation</goal>
                   </goals>
@@ -624,7 +624,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.9.0</version>
+                        <version>0.10.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>phoebus-releases</publishingServerId>


### PR DESCRIPTION
Open API doc build was added recently, it is configured to run in ```install``` phase. This has consequences when deploying to Maven, as the gpg signing is done before the Open API step. This in turn fails the upload.

To try to resolve this I have changed the phase to ```package```.